### PR TITLE
date added beside the version of the last prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It's created and developed in Intel Open Source Technology Center.
 
 [v0.3.6 release note](https://groups.google.com/d/msg/node-webkit/sUamgSnbTzk/0gI-lywN_2IJ)
 
-Prebuilt binaries (v0.3.6):
+Prebuilt binaries (v0.3.6 — Dec 14, 2012):
 
 * Linux: [32bit](http://s3.amazonaws.com/node-webkit/node-webkit-latest-linux-ia32.tar.gz) / [64bit](http://s3.amazonaws.com/node-webkit/node-webkit-latest-linux-x64.tar.gz)
 * Windows: [win32](http://s3.amazonaws.com/node-webkit/node-webkit-latest-win-ia32.zip)


### PR DESCRIPTION
It should be easy to check the date and see whether the most recent prebuilt binaries are fresh, even if a node-webkit's user has forgotten about the exact digits of the previous version's number.

Such dates are already given for the [old versions](https://github.com/rogerwang/node-webkit/wiki/Downloads-of-old-versions) of these binaries.
