### PR TITLE
package binaries in windows and linux remove needles file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 tests/node_modules
+*.pyc
+

--- a/nw.gypi
+++ b/nw.gypi
@@ -329,6 +329,25 @@
       ],
     },
     {
+      'target_name': 'nw_package_bin',
+      'type': 'none',
+      'actions': [
+        {
+          'action_name': 'package_nw_binaries',
+          'variables':{
+            'package_script': '<(DEPTH)/content/nw/tools/package_binaries.py',
+          },
+          'inputs': [
+            '<(package_script)',
+          ],
+          'outputs':[
+            '<(PRODUCT_DIR)/new_package.re',
+          ],
+          'action': ['python', '<(package_script)'],
+        },
+      ],
+    },
+    {
       'target_name': 'nw',
       'type': 'executable',
       'mac_bundle': 1,

--- a/tools/getnwisrelease.py
+++ b/tools/getnwisrelease.py
@@ -1,0 +1,13 @@
+import sys,os,re
+
+nw_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+    'nw_version.h')
+
+f = open(nw_version_h)
+
+
+for line in f:
+  if re.match('#define NW_VERSION_IS_RELEASE', line):
+    release = int(line.split()[2])
+    #print release
+    

--- a/tools/getnwversion.py
+++ b/tools/getnwversion.py
@@ -1,0 +1,23 @@
+import os,re
+
+node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+    'nw_version.h')
+
+f = open(node_version_h)
+
+
+for line in f:
+  if re.match('#define NW_MAJOR_VERSION', line):
+    major = line.split()[2]
+  if re.match('#define NW_MINOR_VERSION', line):
+    minor = line.split()[2]
+  if re.match('#define NW_PATCH_VERSION', line):
+    patch = line.split()[2]
+
+nw_version = '%(major)s.%(minor)s.%(patch)s'% locals()  
+
+#print '%(major)s.%(minor)s.%(patch)s'% locals()
+
+
+
+

--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+import os
+import shutil
+import tarfile
+import sys
+
+
+script_dir = os.path.dirname(__file__)
+nw_root  = os.path.normpath(os.path.join(script_dir, os.pardir))
+project_root = os.path.normpath(os.path.join(nw_root, os.pardir, os.pardir)); 
+#default project path
+project_root = os.path.join(project_root, 'out', 'Release')
+
+
+#parse command line arguments
+"""
+-p <path>, the absolute path of executable files
+""" 
+if '-p' in sys.argv:
+  tmp = sys.argv[sys.argv.index('-p') + 1]
+  if not os.path.isabs(tmp):
+    print 'the path is not an absolute path.\n'
+    exit()
+
+  if not os.path.exists(tmp):
+    print 'the directory does not exist.\n'
+    exit()
+        
+  project_root = tmp
+
+
+
+#get platform information
+if sys.platform.startswith('linux'):
+  platform_name = 'linux'
+  
+if sys.platform in ('win32', 'cygwin'):
+  platform_name = 'win'
+  
+#platform == macox
+
+#judge whether the target exist or not   
+if platform_name == 'linux' and not os.path.exists(
+    os.path.join(project_root, 'nw')):
+  print 'nw file does not exist.\n'
+  exit()  
+
+if platform_name == 'win' and not os.path.exists(
+    os.path.join(project_root, 'nw.exe')):
+  print 'nw file does not exist.\n'
+  exit() 
+  
+  
+required_file_linux = (
+  'nw',
+  'nw.pak',
+  'libffmpegsumo.so',
+)
+
+required_file_win = (
+  'ffmpegsumo.dll',
+  'icudt.dll',
+  'libEGL.dll',
+  'libGLESv2.dll',
+  'nw.exe',
+  'nw.pak',
+)
+
+required_file_mac = (
+                     
+)
+
+
+if (platform_name == 'linux'):
+  required_file = required_file_linux
+
+if (platform_name == 'win'):
+  required_file = required_file_win
+
+#generate binary tar name
+import getnwisrelease
+import getnwversion
+import platform
+
+nw_version = 'v' + getnwversion.nw_version
+is_release = getnwisrelease.release
+
+if is_release == 0:
+  nw_version += '-pre'
+  
+bits = platform.architecture()[0]
+
+if bits == '64bit':
+  arch = 'x64'
+else:
+  arch = 'x86'
+  
+tarname = 'node-webkit-' + nw_version
+
+binary_name = tarname + '-' + platform_name + '-' + arch
+binary_tar = binary_name + '.tar.gz'
+
+#make directory for binary_tar
+binary_store_path = os.path.join(project_root,                                 
+                                 'node-webkit-binaries')
+
+
+if not os.path.exists(binary_store_path):
+  os.mkdir(binary_store_path)
+
+
+binary_full_path = os.path.join(binary_store_path, binary_name)
+binary_tar_full_path = os.path.join(binary_store_path, binary_tar)
+
+
+if os.path.exists(binary_full_path):
+  shutil.rmtree(binary_full_path)
+
+os.mkdir(binary_full_path)
+
+
+#copy file to binary
+print 'Begin copy file.'
+for file in required_file:
+  shutil.copy(os.path.join(project_root, file),
+              os.path.join(binary_full_path, file))
+
+print 'copy file end.\n'
+
+
+
+
+
+if (os.path.isfile(binary_tar_full_path)):
+  os.remove(binary_tar_full_path)
+print 'Begin tar file'
+tar = tarfile.open(binary_tar_full_path, 'w:gz')
+tar.add(binary_full_path, os.path.basename(binary_full_path))
+tar.close()
+print 'tar file end.\n'
+
+
+print 'the binaries files store in path:', os.path.normpath(
+    os.path.join(os.getcwd(), binary_store_path))
+
+


### PR DESCRIPTION
Which would be better?
     1. we copy all .dll files in windows, or .so files in linux.
     2. List required files. And copy them.  
