### PR TITLE
[API][WIN] Fix maximize event doesn't trigger when double click the title bar. Fix #257

### DIFF
--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -569,15 +569,19 @@ void NativeWindowWin::OnFocus() {
 }
 
 bool NativeWindowWin::ExecuteWindowsCommand(int command_id) {
-  if (command_id == SC_MINIMIZE) {
+  // Windows uses the 4 lower order bits of |command_id| for type-specific
+  // information so we must exclude this when comparing.
+  static const int sc_mask = 0xFFF0;
+
+  if ((command_id & sc_mask) == SC_MINIMIZE) {
     is_minimized_ = true;
     shell()->SendEvent("minimize");
-  } else if (command_id == SC_RESTORE && is_minimized_) {
+  } else if ((command_id & sc_mask) == SC_RESTORE && is_minimized_) {
     is_minimized_ = false;
     shell()->SendEvent("restore");
-  } else if (command_id == SC_RESTORE && !is_minimized_) {
+  } else if ((command_id & sc_mask) == SC_RESTORE && !is_minimized_) {
     shell()->SendEvent("unmaximize");
-  } else if (command_id == SC_MAXIMIZE) {
+  } else if ((command_id & sc_mask) == SC_MAXIMIZE) {
     shell()->SendEvent("maximize");
   }
 


### PR DESCRIPTION
Windows uses the 4 lower order bits of |command-id| for type-specific information so we must exclude this when comparing. For more, please take a look at [link](https://code.google.com/codesearch#OAMlx_jo-ck/src/ui/views/win/hwnd_message_handler.cc&exact_package=chromium&q=SC_MAXIMIZE&l=1917)
