### PR TITLE
Add 'chromium-args'

### DIFF
--- a/src/common/shell_switches.cc
+++ b/src/common/shell_switches.cc
@@ -45,6 +45,7 @@ const char kmName[]   = "name";
 const char kmWebkit[] = "webkit";
 const char kmNodejs[] = "nodejs";
 const char kmWindow[] = "window";
+const char kmChromiumArgs[] = "chromium-args";
 
 // Allows only one instance of the app.
 const char kmSingleInstance[] = "single-instance";

--- a/src/common/shell_switches.h
+++ b/src/common/shell_switches.h
@@ -22,6 +22,7 @@ extern const char kmName[];
 extern const char kmWebkit[];
 extern const char kmNodejs[];
 extern const char kmWindow[];
+extern const char kmChromiumArgs[];
 
 extern const char kmSingleInstance[];
 

--- a/src/nw_package.h
+++ b/src/nw_package.h
@@ -81,6 +81,9 @@ class Package {
   bool ExtractPath();
   bool ExtractPackage(const FilePath& zip_file, FilePath* where);
 
+  // Read chromium command line args from the package.json if specifed.
+  void ReadChromiumArgs();
+
   // Convert error info into data url.
   void ReportError(const std::string& title, const std::string& content);
 


### PR DESCRIPTION
Add 'chromium-args' in package.json, which can be used to specify chromium command line args in package.json, fix #307. 

If this pull request is OK to merge, I will update the wiki also. 
