### PR TITLE
[API] Change chromium_args sperator from whitespace to semicolon.

### DIFF
--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -43,6 +43,9 @@
 
 namespace nw {
 
+// Sperator for the string from |chromium_args| of |package.json|.
+const char kChromiumArgsSeparator = ';';
+
 namespace {
 
 #ifndef PATH_MAX
@@ -368,7 +371,7 @@ void Package::ReadChromiumArgs() {
     return;
 
   std::vector<std::string> chromium_args;
-  base::SplitString(args, ' ', &chromium_args);
+  base::SplitString(args, kChromiumArgsSeparator, &chromium_args);
 
   CommandLine* command_line = CommandLine::ForCurrentProcess();
 


### PR DESCRIPTION
the following case:
`"chromium-args": "--js-flags=--harmony-proxies --js-flags=--harmony_collections"`, 
only `--js-flags=--harmony_collections` work, the first one will be overrode. Change to other separator, like ; 

The new usage of this api will become
`"chromium-args": "--js-flags=--harmony-proxies --harmony_collections;--disable-accelerated-video"`
