### PR TITLE
[API] Distinguish 'js-flags' from 'chromium-args' for more natural feel

### DIFF
--- a/src/common/shell_switches.cc
+++ b/src/common/shell_switches.cc
@@ -46,6 +46,7 @@ const char kmWebkit[] = "webkit";
 const char kmNodejs[] = "nodejs";
 const char kmWindow[] = "window";
 const char kmChromiumArgs[] = "chromium-args";
+const char kmJsFlags[] = "js-flags";
 
 // Allows only one instance of the app.
 const char kmSingleInstance[] = "single-instance";

--- a/src/common/shell_switches.h
+++ b/src/common/shell_switches.h
@@ -23,6 +23,7 @@ extern const char kmWebkit[];
 extern const char kmNodejs[];
 extern const char kmWindow[];
 extern const char kmChromiumArgs[];
+extern const char kmJsFlags[];
 
 extern const char kmSingleInstance[];
 

--- a/src/nw_package.h
+++ b/src/nw_package.h
@@ -84,6 +84,9 @@ class Package {
   // Read chromium command line args from the package.json if specifed.
   void ReadChromiumArgs();
 
+  // Read js flags from the package.json if specifed.
+  void ReadJsFlags();
+
   // Convert error info into data url.
   void ReportError(const std::string& title, const std::string& content);
 


### PR DESCRIPTION
1. Add `js-flags` in the manifest field.
2. About `chromium-args`, now can deal with case like `"key='value1 value2'"`
