### PR TITLE
Implement HandleExternalProtocol of the ShellResourceDispatcherHostDelegate

### DIFF
--- a/src/browser/shell_resource_dispatcher_host_delegate.h
+++ b/src/browser/shell_resource_dispatcher_host_delegate.h
@@ -22,6 +22,9 @@ class ShellResourceDispatcherHostDelegate
                                  net::AuthChallengeInfo* auth_info) OVERRIDE;
   virtual ResourceDispatcherHostLoginDelegate* CreateLoginDelegate(
       net::AuthChallengeInfo* auth_info, net::URLRequest* request) OVERRIDE;
+  virtual bool HandleExternalProtocol(const GURL& url,
+                                      int child_id,
+                                      int route_id) OVERRIDE;
 
   // Used for content_browsertests.
   void set_login_request_callback(


### PR DESCRIPTION
Code borrow from [external_protocol_handler](https://code.google.com/p/chromium/codesearch#chrome/src/chrome/browser/external_protocol/external_protocol_handler.h&cl=GROK&l=92). Fix #403.
