### PR TITLE
[API][WIN] "position": "mouse" support on Windows.

### DIFF
--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -355,6 +355,16 @@ void NativeWindowWin::SetPosition(const std::string& position) {
   if (position == "center") {
     gfx::Rect bounds = window_->GetWindowBoundsInScreen();
     window_->CenterWindow(gfx::Size(bounds.width(), bounds.height()));
+  } else if (position == "mouse") {
+    gfx::Rect bounds = window_->GetWindowBoundsInScreen();
+    POINT pt;
+    if (::GetCursorPos(&pt)) {
+      int x = pt.x - (bounds.width() >> 1);
+      int y = pt.y - (bounds.height() >> 1);
+      bounds.set_x(x > 0 ? x : 0);
+      bounds.set_y(y > 0 ? y : 0);
+      window_->SetBoundsConstrained(bounds);
+    }
   }
 }
 


### PR DESCRIPTION
For the window field of `package.json`, the code for `"position": "mouse"` is lost on Windows Platform. 

Fix #528. 
