### PR TITLE
[WIN] Fix build error of rebase.

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -256,6 +256,7 @@
               },
             },
           },
+          'msvs_disabled_warnings': [ 4800 ],
         }],  # OS=="win"
       ],
     },

--- a/src/api/menu/menu.h
+++ b/src/api/menu/menu.h
@@ -109,7 +109,7 @@ class Menu : public Base {
 #elif defined(OS_WIN)
   friend class nw::NativeWindowWin;
 
-  void Rebuild(const gfx::NativeMenu *parent_menu = NULL);
+  void Rebuild(const HMENU *parent_menu = NULL);
 
   // Flag to indicate the menu has been modified since last show, so we should
   // rebuild the menu before next show.

--- a/src/api/menu/menu_win.cc
+++ b/src/api/menu/menu_win.cc
@@ -140,25 +140,22 @@ void Menu::Popup(int x, int y, content::Shell* shell) {
                    views::Menu2::ALIGN_TOPLEFT);
 }
 
-void Menu::Rebuild(const gfx::NativeMenu *parent_menu) {
+void Menu::Rebuild(const HMENU *parent_menu) {
   if (is_menu_modified_) {
     // Refresh menu before show.
-    menu_->Rebuild();
+    menu_->Rebuild(NULL);
     menu_->UpdateStates();
     for (size_t index = 0; index < icon_bitmaps_.size(); ++index) {
       ::DeleteObject(icon_bitmaps_[index]);
     }
     icon_bitmaps_.clear();
 
-    gfx::NativeMenu native_menu = parent_menu == NULL ?
+    HMENU native_menu = parent_menu == NULL ?
         menu_->GetNativeMenu() : *parent_menu;
 
-    int first_item_index =
-        menu_model_->GetFirstItemIndex(native_menu);
-    for (int menu_index = first_item_index;
-          menu_index < first_item_index + menu_model_->GetItemCount();
-          ++menu_index) {
-      int model_index = menu_index - first_item_index;
+    for (int model_index = 0;
+         model_index < menu_model_->GetItemCount();
+         ++model_index) {
       int command_id = menu_model_->GetCommandIdAt(model_index);
 
       if (menu_model_->GetTypeAt(model_index) == ui::MenuModel::TYPE_COMMAND ||

--- a/src/api/menuitem/menuitem_win.cc
+++ b/src/api/menuitem/menuitem_win.cc
@@ -20,7 +20,7 @@
 
 #include "content/nw/src/api/menuitem/menuitem.h"
 
-#include "base/file_path.h"
+#include "base/files/file_path.h"
 #include "base/utf_string_conversions.h"
 #include "base/values.h"
 #include "content/nw/src/api/dispatcher_host.h"
@@ -80,7 +80,7 @@ void MenuItem::SetIcon(const std::string& icon) {
   content::Shell* shell = content::Shell::FromRenderViewHost(
       dispatcher_host()->render_view_host());
   nw::Package* package = shell->GetPackage();
-  package->GetImage(FilePath::FromUTF8Unsafe(icon), &icon_);
+  package->GetImage(base::FilePath::FromUTF8Unsafe(icon), &icon_);
 }
 
 void MenuItem::SetTooltip(const std::string& tooltip) {

--- a/src/api/tray/tray_win.cc
+++ b/src/api/tray/tray_win.cc
@@ -20,7 +20,7 @@
 
 #include "content/nw/src/api/tray/tray.h"
 
-#include "base/file_path.h"
+#include "base/files/file_path.h"
 #include "base/utf_string_conversions.h"
 #include "base/values.h"
 #include "chrome/browser/status_icons/status_icon.h"
@@ -79,7 +79,7 @@ void Tray::SetIcon(const std::string& path) {
   content::Shell* shell = content::Shell::FromRenderViewHost(
       dispatcher_host()->render_view_host());
   nw::Package* package = shell->GetPackage();
-  package->GetImage(FilePath::FromUTF8Unsafe(path), &icon);
+  package->GetImage(base::FilePath::FromUTF8Unsafe(path), &icon);
 
   if (!icon.IsEmpty())
     status_icon_->SetImage(*icon.ToImageSkia());

--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -24,7 +24,6 @@
 #include "base/values.h"
 #include "base/win/wrapped_window_proc.h"
 #include "chrome/browser/platform_util.h"
-#include "chrome/common/extensions/draggable_region.h"
 #include "content/nw/src/api/menu/menu.h"
 #include "content/nw/src/browser/native_window_toolbar_win.h"
 #include "content/nw/src/common/shell_switches.h"
@@ -33,6 +32,8 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_view.h"
+#include "extensions/common/draggable_region.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "ui/base/hit_test.h"
 #include "ui/base/win/hwnd_util.h"
@@ -610,7 +611,9 @@ void NativeWindowWin::OnViewWasResized() {
   int height = sz.height(), width = sz.width();
   gfx::Path path;
   path.addRect(0, 0, width, height);
-  SetWindowRgn(web_contents()->GetNativeView(), path.CreateNativeRegion(), 1);
+  SetWindowRgn(web_contents()->GetView()->GetNativeView(),
+               path.CreateNativeRegion(),
+               1);
 
   SkRegion* rgn = new SkRegion;
   if (!window_->IsFullscreen()) {

--- a/src/browser/shell_download_manager_delegate_win.cc
+++ b/src/browser/shell_download_manager_delegate_win.cc
@@ -42,21 +42,21 @@ namespace content {
 void ShellDownloadManagerDelegate::ChooseDownloadPath(
     int32 download_id,
     const DownloadTargetCallback& callback,
-    const FilePath& suggested_path) {
+    const base::FilePath& suggested_path) {
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
   DownloadItem* item = download_manager_->GetDownload(download_id);
   if (!item || (item->GetState() != DownloadItem::IN_PROGRESS))
     return;
 
-  FilePath result;
+  base::FilePath result;
 
-  std::wstring file_part = FilePath(suggested_path).BaseName().value();
+  std::wstring file_part = base::FilePath(suggested_path).BaseName().value();
   wchar_t file_name[MAX_PATH];
   base::wcslcpy(file_name, file_part.c_str(), arraysize(file_name));
   OPENFILENAME save_as;
   ZeroMemory(&save_as, sizeof(save_as));
   save_as.lStructSize = sizeof(OPENFILENAME);
-  save_as.hwndOwner = item->GetWebContents()->GetNativeView();
+  save_as.hwndOwner = item->GetWebContents()->GetView()->GetNativeView();
   save_as.lpstrFile = file_name;
   save_as.nMaxFile = arraysize(file_name);
 
@@ -69,7 +69,7 @@ void ShellDownloadManagerDelegate::ChooseDownloadPath(
                   OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST;
 
   if (GetSaveFileName(&save_as))
-    result = FilePath(std::wstring(save_as.lpstrFile));
+    result = base::FilePath(std::wstring(save_as.lpstrFile));
 
   callback.Run(result, DownloadItem::TARGET_DISPOSITION_PROMPT,
                DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS, result);

--- a/src/browser/shell_javascript_dialog_win.cc
+++ b/src/browser/shell_javascript_dialog_win.cc
@@ -97,7 +97,7 @@ ShellJavaScriptDialog::ShellJavaScriptDialog(
     JavaScriptMessageType message_type,
     const string16& message_text,
     const string16& default_prompt_text,
-    const JavaScriptDialogCreator::DialogClosedCallback& callback)
+    const JavaScriptDialogManager::DialogClosedCallback& callback)
     : creator_(creator),
       callback_(callback),
       message_text_(message_text),

--- a/src/media/media_internals.cc
+++ b/src/media/media_internals.cc
@@ -89,25 +89,6 @@ MediaInternals* MediaInternals::GetInstance() {
 
 MediaInternals::~MediaInternals() {}
 
-void MediaInternals::OnDeleteAudioStream(void* host, int stream_id) {
-}
-
-void MediaInternals::OnSetAudioStreamPlaying(
-    void* host, int stream_id, bool playing) {
-}
-
-void MediaInternals::OnSetAudioStreamStatus(
-    void* host, int stream_id, const std::string& status) {
-}
-
-void MediaInternals::OnSetAudioStreamVolume(
-    void* host, int stream_id, double volume) {
-}
-
-void MediaInternals::OnMediaEvent(
-    int render_process_id, const media::MediaLogEvent& event) {
-}
-
 void MediaInternals::OnCaptureDevicesOpened(
     int render_process_id,
     int render_view_id,

--- a/src/media/media_internals.h
+++ b/src/media/media_internals.h
@@ -42,18 +42,6 @@ class MediaInternals : public content::MediaObserver {
   static MediaInternals* GetInstance();
 
   // Overridden from content::MediaObserver:
-  virtual void OnDeleteAudioStream(void* host, int stream_id) OVERRIDE;
-  virtual void OnSetAudioStreamPlaying(void* host,
-                                       int stream_id,
-                                       bool playing) OVERRIDE;
-  virtual void OnSetAudioStreamStatus(void* host,
-                                      int stream_id,
-                                      const std::string& status) OVERRIDE;
-  virtual void OnSetAudioStreamVolume(void* host,
-                                      int stream_id,
-                                      double volume) OVERRIDE;
-  virtual void OnMediaEvent(int render_process_id,
-                            const media::MediaLogEvent& event) OVERRIDE;
   virtual void OnCaptureDevicesOpened(
       int render_process_id,
       int render_view_id,

--- a/src/nw_shell.cc
+++ b/src/nw_shell.cc
@@ -424,7 +424,7 @@ void Shell::DidNavigateMainFramePostCommit(WebContents* web_contents) {
   window()->SetToolbarUrlEntry(web_contents->GetURL().spec());
 }
 
-JavaScriptDialogManager* Shell::GetJavaScriptDialogCreator() {
+JavaScriptDialogManager* Shell::GetJavaScriptDialogManager() {
   if (!dialog_creator_.get())
     dialog_creator_.reset(new ShellJavaScriptDialogCreator());
   return dialog_creator_.get();

--- a/src/nw_shell.h
+++ b/src/nw_shell.h
@@ -146,7 +146,7 @@ class Shell : public WebContentsDelegate,
                                   const FilePath& path) OVERRIDE;
   virtual void DidNavigateMainFramePostCommit(
       WebContents* web_contents) OVERRIDE;
-  virtual JavaScriptDialogManager* GetJavaScriptDialogCreator() OVERRIDE;
+  virtual JavaScriptDialogManager* GetJavaScriptDialogManager() OVERRIDE;
   virtual void RequestToLockMouse(WebContents* web_contents,
                                   bool user_gesture,
                                   bool last_unlocked_by_target) OVERRIDE;

--- a/src/shell_content_client.cc
+++ b/src/shell_content_client.cc
@@ -43,7 +43,13 @@ string16 ShellContentClient::GetLocalizedString(int message_id) const {
 base::StringPiece ShellContentClient::GetDataResource(
     int resource_id,
     ui::ScaleFactor scale_factor) const {
-  return ResourceBundle::GetSharedInstance().GetRawDataResource(resource_id);
+  return ResourceBundle::GetSharedInstance().GetRawDataResourceForScale(
+      resource_id, scale_factor);
+}
+
+base::RefCountedStaticMemory* ShellContentClient::GetDataResourceBytes(
+    int resource_id) const {
+  return ResourceBundle::GetSharedInstance().LoadDataResourceBytes(resource_id);
 }
 
 gfx::Image& ShellContentClient::GetNativeImageNamed(int resource_id) const {

--- a/src/shell_content_client.h
+++ b/src/shell_content_client.h
@@ -22,6 +22,8 @@ class ShellContentClient : public ContentClient {
   virtual base::StringPiece GetDataResource(
       int resource_id,
       ui::ScaleFactor scale_factor) const OVERRIDE;
+  virtual base::RefCountedStaticMemory* GetDataResourceBytes(
+      int resource_id) const OVERRIDE;
   virtual gfx::Image& GetNativeImageNamed(int resource_id) const OVERRIDE;
   virtual bool CanHandleWhileSwappedOut(const IPC::Message& msg) OVERRIDE;
 };


### PR DESCRIPTION
1. Disable the warning of 4800. The warning is caused by forcing value to
   bool(performance warning).
2. gfx::NativeMenu is removed, use HMENU directly.
3. NativeMenuWin::Rebuild add one parameter: InsertionDelegate*, it can be NULL
   in our code path.
4. Upstream code move |base/file_path.h| to |base/files/file_path.h|,
   move |chrome/common/extensions/draggable_region.h| to |extensions/common/draggable_region.h|
5. |WebContents::GetNativeView| is removed. Using ->GetView()->GetNativeView();
6. |JavaScriptDialogCreator| is renamed to |JavaScriptDialogManager|
7. Several method in the base class |content::MediaObserver| of |MediaInternals|
   is removed, it's OK for us to remove it because we do nothing before.
8. Base class: |content::ContentClient| add method |GetDataResourceBytes|, so
   |content::ShellContentClient| should also override it.
