### PR TITLE
[WIN] Enabling Visual Styles, so that tooltips can show up. Fix #72.

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -423,6 +423,13 @@
       },
       'msvs_settings': {
         'VCLinkerTool': {
+          'AdditionalOptions': [
+            "\"/manifestdependency:type='win32' "
+                "name='Microsoft.Windows.Common-Controls' "
+                "version='6.0.0.0' "
+                "processorArchitecture='*' "
+                "publicKeyToken='6595b64144ccf1df' language='*'\"",
+          ],
           'SubSystem': '2',  # Set /SUBSYSTEM:WINDOWS
         },
       },


### PR DESCRIPTION
Enabling Visual Styles, so that tooltips can show up when hover. Fix #72.

For more details: http://msdn.microsoft.com/en-us/library/windows/desktop/bb773175%28v=vs.85%29.aspx

Thanks the help from chromium-dev: [Link](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-dev/_ztNZjLZCjs%5B1-25-false%5D)
