### PR TITLE
fix out-of-fd issue on OSX

### DIFF
--- a/src/shell_browser_main_parts.h
+++ b/src/shell_browser_main_parts.h
@@ -38,6 +38,7 @@ class ShellBrowserMainParts : public BrowserMainParts {
   virtual ~ShellBrowserMainParts();
 
   // BrowserMainParts overrides.
+  virtual void PreEarlyInitialization() OVERRIDE;
   virtual void PreMainMessageLoopStart() OVERRIDE;
   virtual void PreMainMessageLoopRun() OVERRIDE;
   virtual void PostMainMessageLoopStart() OVERRIDE;


### PR DESCRIPTION
Sometimes app are loading large number of resources in a short period
of time. This will hit the limit of fd on Mac (256)
