### PR TITLE
Fix typo in logging allocation of object with unknown type

### DIFF
--- a/src/api/dispatcher_host.cc
+++ b/src/api/dispatcher_host.cc
@@ -105,7 +105,7 @@ void DispatcherHost::OnAllocateObject(int object_id,
   } else if (type == "Window") {
     objects_registry_.AddWithID(new Window(object_id, this, option), object_id);
   } else {
-    LOG(ERROR) << "Allocate an object of unknow type: " << type;
+    LOG(ERROR) << "Allocate an object of unknown type: " << type;
     objects_registry_.AddWithID(new Base(object_id, this, option), object_id);
   }
 }


### PR DESCRIPTION
fixes error message

ERROR:dispatcher_host.cc(108)] Allocate an object of unknow type: Object
