### PR TITLE
link to https://github.com/rogerwang/node-webkit/wiki/Using-Node-modules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For more information on how to write/package/run apps, see:
 
 * [How to run apps](https://github.com/rogerwang/node-webkit/wiki/How-to-run-apps)
 * [How to package and distribute your apps](https://github.com/rogerwang/node-webkit/wiki/How-to-package-and-distribute-your-apps)
-* [How to use 3rd party node.js modules in node-webkit](https://github.com/rogerwang/node-webkit/wiki/How-to-use-3rd-party-node.js-modules-in-node-webkit)
+* [How to use Node.js modules in node-webkit](https://github.com/rogerwang/node-webkit/wiki/Using-Node-modules)
 
 And our [Wiki](https://github.com/rogerwang/node-webkit/wiki) for much more.
 


### PR DESCRIPTION
The wiki page has been renamed (#823), and thus the former link is no longer valid.
