### PR TITLE
[tool] fix 'dist' target wrong package name on Mac and Win

### DIFF
--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -105,6 +105,8 @@ if bits == '64bit':
 else:
   arch = 'ia32'
 
+if (platform_name == 'win' or platform_name == 'osx'):
+  arch = 'ia32'
 
 tarname = 'node-webkit-' + nw_version
 


### PR DESCRIPTION
fix 'dist' target wrong package name on Mac and Win
