### PR TITLE
remove alert title on OSX

### DIFF
--- a/src/browser/shell_javascript_dialog_mac.mm
+++ b/src/browser/shell_javascript_dialog_mac.mm
@@ -126,7 +126,7 @@ ShellJavaScriptDialog::ShellJavaScriptDialog(
   }
   [alert setDelegate:helper_];
   [alert setInformativeText:base::SysUTF16ToNSString(message_text)];
-  [alert setMessageText:@"Javascript alert"];
+  [alert setMessageText:@""];
   [alert addButtonWithTitle:@"OK"];
   if (!one_button) {
     NSButton* other = [alert addButtonWithTitle:@"Cancel"];


### PR DESCRIPTION
fix issue: https://github.com/rogerwang/node-webkit/issues/395

remove alert, confirm, prompt message box title on Mac OSX.
