### PR TITLE
Fix showItemInFolder not work because of relative path

### DIFF
--- a/src/api/shell/shell.cc
+++ b/src/api/shell/shell.cc
@@ -57,17 +57,25 @@ void Shell::Call(const std::string& method,
       std::vector<base::FilePath::StringType> components;
       file_path.GetComponents(&components);
       std::vector<base::FilePath::StringType>::const_iterator it = components.begin();
-      
+#if defined(OS_POSIX)
+      const base::FilePath::StringType home_path = "~";
+      const base::FilePath::StringType current_path = ".";
+      const base::FilePath::StringType parent_path = "..";
+#elif defined(OS_WIN)
+      const base::FilePath::StringType home_path = L"~";
+      const base::FilePath::StringType current_path = L".";
+      const base::FilePath::StringType parent_path = L"..";
+#endif
       for (; it != components.end(); ++it) {
 	const base::FilePath::StringType& component = *it;  
-	if (component == "~") {
+	if (component == home_path) {
 	  package_path = file_path;
 	  break;
 	}
 	else {
-	  if (component == ".")
+	  if (component == current_path)
 	    ;//do nothing
-	  else if (component == "..") 
+	  else if (component == parent_path) 
 	    package_path = package_path.DirName();
 	  else 
 	    package_path = package_path.Append(component);
@@ -75,7 +83,7 @@ void Shell::Call(const std::string& method,
       }
       file_path = package_path;
     }
-    
+    DLOG(INFO) << file_path.value().c_str();
     platform_util::ShowItemInFolder(file_path);
   } else {
     NOTREACHED() << "Calling unknown method " << method << " of Shell";


### PR DESCRIPTION
see #913.
Linux: at last it will call `execvp(argv_cstr[0], argv_cstr.get());`
if the argv is relative path, it opens the file relative to the place, where it is launched

Mac:at last it will call `selectFile`.According to [this](https://developer.apple.com/library/mac/#documentation/cocoa/reference/ApplicationKit/Classes/NSWorkspace_Class/Reference/Reference.html), `[[NSWorkspace sharedWorkspace] selectFile` only receive fullPath 

windows: When it call `desktop->ParseDisplayName`.According to [this](http://msdn.microsoft.com/en-us/library/windows/desktop/bb775090)
`ParseDisplayName is not expected to handle the relative path or parent folder 
indicators(".\" or "..\"). It is up to the caller to remove these appropriately.`

so I change the relative path to full path
