### PR TITLE
[test]fix the exception that's raised by proxy test

### DIFF
--- a/tests/automatic_tests/proxy/mocha_test.js
+++ b/tests/automatic_tests/proxy/mocha_test.js
@@ -17,7 +17,7 @@ describe('proxy', function(){
   after(function(){
     this.timeout(0);
     if (os.platform() == "win32"){
-      fs.unlink('/test.reg', function (err) {
+      fs.unlink('c:/test.reg', function (err) {
         if (err) console.log(err);
       });
     }


### PR DESCRIPTION
the former test should be executed under `c` disk by default. otherwise, the `.reg` file that's generated under the root of `c` disk will not be deleted after the test, and then an exception will be threw about `fail to unlink file`. it's a mistake about the path `/`, which means the root path of the current path. but not `c`. I've revised it to `c` explicitly.
