### PR TITLE
[manual testcase] Added test for issue #434

### DIFF
--- a/tests/manual_tests/autocomplete/index.html
+++ b/tests/manual_tests/autocomplete/index.html
@@ -1,0 +1,16 @@
+<html>
+    <body>
+        <p>
+            <h3>Test case for GitHub issue #434<br>(lack of autocomplete if "id" or "name" attribute is used for input tag)</h3>
+        </p>
+        <p>
+            Please type letter "b" in this input field, it should present an autocomplete list with "Bart" entry in it. 
+            <input name="element-name" id="element-id" type="text" list="characters" style="width:400px" autofocus>
+            <datalist id="characters">
+                <option value="Homer Simpson">
+                <option value="Bart">
+                <option value="Fred Flinstone">
+            </datalist>
+        </p>
+    </body>
+</html>

--- a/tests/manual_tests/autocomplete/package.json
+++ b/tests/manual_tests/autocomplete/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "nw-test",
+    "main": "index.html"
+}


### PR DESCRIPTION
This a manual test for issue #434, testing autocomplete list appears in the presence of "id" and "name" attributes in the input field definition.
