### PR TITLE
Fix -webkit-app-region: drag don't work any more once it maximized.

### DIFF
--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -668,11 +668,11 @@ void NativeWindowWin::OnViewWasResized() {
                1);
 
   SkRegion* rgn = new SkRegion;
-  if (!window_->IsFullscreen() && !window_->IsMaximized()) {
+  if (!window_->IsFullscreen()) {
     if (draggable_region())
       rgn->op(*draggable_region(), SkRegion::kUnion_Op);
 
-    if (!has_frame() && CanResize()) {
+    if (!has_frame() && CanResize() && !window_->IsMaximized()) {
       rgn->op(0, 0, width, kResizeInsideBoundsSize, SkRegion::kUnion_Op);
       rgn->op(0, 0, kResizeInsideBoundsSize, height, SkRegion::kUnion_Op);
       rgn->op(width - kResizeInsideBoundsSize, 0, width, height,


### PR DESCRIPTION
Part of #1168.

This feature is broken by commit da2b25c991d8c9b505fce21ac5a331057c726c25.

TEST=1. Run the nw-sample-apps\frameless-window;
            2. Show the titlebar by cliking "Top Titlebar"
            3. Double click the maximize the windows.
            4. Double click the tilte bar should be able to unmaximize the window.
