### PR TITLE
Window.zoomLevel, wrong default value; in `Window.zoomLevel = <val>`, <val> needs to be a list??

### DIFF
--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -196,7 +196,7 @@ Window.prototype.__defineGetter__('title', function() {
 });
 
 Window.prototype.__defineSetter__('zoomLevel', function(level) {
-  CallObjectMethodSync(this, 'SetZoomLevel', level);
+  CallObjectMethodSync(this, 'SetZoomLevel', [level]);
 });
 
 Window.prototype.__defineGetter__('zoomLevel', function() {


### PR DESCRIPTION
When mucking about in the Developer tools console in empty node-webkit (started as just `$ nw`, I find:

```
> var gui = require('nw.gui');
  undefined
> var win = gui.Window.get();
  undefined
> win.zoomLevel
  0
```

According to the WebKit API, at least: http://webkitgtk.org/reference/webkitgtk/stable/webkitgtk-webkitwebview.html#WebKitWebView--zoom-level
this default value should be 1, I think.

Back to the Console:

```
> win.zoomLevel = 1.2;
  Error: Unable to convert 'args' passed to CallObjectMethodSync
```

From looking around the source code line where this error message is being produced:

[src/api/bindings_common.cc:149](../blob/master/src/api/bindings_common.cc)

I get that this function is expecting a list. Why a list and not a scalar number?

If I test in the Console:

```
> win.zoomLevel = [1.2];
```

and switch back to the main window, it appears setting the zoom level has indeed worked.

Back to the Console:

```
> win.zoomLevel
  1.2000000476837158
```

Besides the obvious binary rounding error, the vaue is correct, but is a scalar again.
What gives?
