### PR TITLE
fix mac build by adding the namespace declaration for breakpad

### DIFF
--- a/src/breakpad_mac.h
+++ b/src/breakpad_mac.h
@@ -5,6 +5,7 @@
 #ifndef CHROME_APP_BREAKPAD_MAC_H_
 #define CHROME_APP_BREAKPAD_MAC_H_
 
+namespace breakpad {
 // This header defines the Chrome entry points for Breakpad integration.
 
 // Initializes Breakpad.
@@ -17,5 +18,6 @@ void InitCrashProcessInfo();
 
 // Is Breakpad enabled?
 bool IsCrashReporterEnabled();
+}
 
 #endif  // CHROME_APP_BREAKPAD_MAC_H_


### PR DESCRIPTION
Signed-off-by: Chris Granger ibdknox@gmail.com
