### PR TITLE
[os x]Add support for tray click event on os x

### DIFF
--- a/src/api/tray/tray.h
+++ b/src/api/tray/tray.h
@@ -29,8 +29,10 @@
 #if defined(OS_MACOSX)
 #if __OBJC__
 @class NSStatusItem;
+@class MacTrayObserver;
 #else
 class NSStatusItem;
+class MacTrayObserver;
 #endif  // __OBJC__
 #elif defined(TOOLKIT_GTK)
 #include <gtk/gtk.h>
@@ -70,6 +72,7 @@ class Tray : public Base {
 
 #if defined(OS_MACOSX)
   __block NSStatusItem* status_item_;
+  MacTrayObserver* status_observer_;
 #elif defined(TOOLKIT_GTK)
   GtkStatusIcon* status_item_;
 

--- a/src/api/tray/tray.js
+++ b/src/api/tray/tray.js
@@ -36,7 +36,7 @@ function Tray(option) {
     option.shadowIcon = String(option.icon);
     option.icon = nw.getAbsolutePath(option.icon);
   }
-  
+
   if (option.hasOwnProperty('alticon')) {
     option.shadowAlticon = String(option.alticon);
     option.alticon = nw.getAbsolutePath(option.alticon);
@@ -44,6 +44,14 @@ function Tray(option) {
 
   if (option.hasOwnProperty('tooltip'))
     option.tooltip = String(option.tooltip);
+
+  if (option.hasOwnProperty('click')) {
+    if (typeof option.click != 'function') {
+      throw new String("'click' must be a valid Function");
+    } else {
+      this.click = option.click;
+    }
+   }
 
   if (option.hasOwnProperty('menu')) {
     if (v8_util.getConstructorName(option.menu) != 'Menu')
@@ -119,4 +127,14 @@ Tray.prototype.remove = function() {
   nw.callObjectMethod(this, 'Remove', []);
 }
 
+Tray.prototype.handleEvent = function(ev) {
+ if (ev == 'click') {
+   // Emit click handler
+   if (typeof this.click == 'function'){
+     this.click();
+   }
+ }
+ // Emit generate event handler
+ exports.Base.prototype.handleEvent.apply(this, arguments);
+}
 exports.Tray = Tray;

--- a/src/api/tray/tray_mac.mm
+++ b/src/api/tray/tray_mac.mm
@@ -22,15 +22,39 @@
 
 #include "base/values.h"
 #import <Cocoa/Cocoa.h>
+#include "content/nw/src/api/dispatcher_host.h"
 #include "content/nw/src/api/menu/menu.h"
 
-namespace nwapi {
 
+@interface MacTrayObserver : NSObject {
+@private
+    nwapi::Tray* tray_;
+}
+- (void)setBacking:(nwapi::Tray*)tray_;
+- (void)onClick:(id)sender;
+@end
+
+@implementation MacTrayObserver
+- (void)setBacking:(nwapi::Tray*)newTray {
+    tray_ = newTray;
+}
+- (void)onClick:(id)sender {
+    base::ListValue args;
+    tray_->dispatcher_host()->SendEvent(tray_,"click",args);
+}
+@end
+
+namespace nwapi {
+    
 void Tray::Create(const base::DictionaryValue& option) {
   NSStatusBar *status_bar = [NSStatusBar systemStatusBar];
+  MacTrayObserver* observer = [[MacTrayObserver alloc] init];
+  [observer setBacking:this];
   status_item_ = [status_bar statusItemWithLength:NSVariableStatusItemLength];
   [status_item_ setHighlightMode:YES];
   [status_item_ retain];
+  [status_item_ setTarget:observer];
+  [status_item_ setAction:@selector(onClick:)];
 }
 
 void Tray::ShowAfterCreate() {
@@ -71,6 +95,8 @@ void Tray::SetTooltip(const std::string& tooltip) {
 }
 
 void Tray::SetMenu(Menu* menu) {
+  [status_item_ setTarget:nil];
+  [status_item_ setAction:nil];
   [status_item_ setMenu:menu->menu_];
 }
 


### PR DESCRIPTION
As @trevorlinton doesn't created a pull request for this for the last 4 month I am doing it now. This will fix Issue #510. 

Simple example:  

``` html
<html>
<body>
  <div>Click on the tray icon</div>
  <script>
    // Load library
    var gui = require('nw.gui');

    // Reference to tray
    var tray = new gui.Tray({ icon: 'icon.png' });

    // Alert on click
    tray.on('click', function() {
      alert("tray clicked");
    });
  </script>
</body>
</html>
```
