### PR TITLE
[mac] Native Keyboard Shortcuts

### DIFF
--- a/src/api/menuitem/menuitem_mac.mm
+++ b/src/api/menuitem/menuitem_mac.mm
@@ -42,11 +42,18 @@ void MenuItem::Create(const base::DictionaryValue& option) {
   } else {
     std::string label;
     option.GetString("label", &label);
-
+    
+    NSString* keyEqu = @"";
+    
+    std::string keyEquStr;
+    if (option.GetString("shortcut", &keyEquStr) && !keyEquStr.empty()){
+        keyEqu = [NSString stringWithUTF8String:keyEquStr.c_str()];
+    }
+      
     menu_item_ = [[NSMenuItem alloc]
        initWithTitle:[NSString stringWithUTF8String:label.c_str()]
        action: @selector(invoke:)
-       keyEquivalent: @""];
+       keyEquivalent: keyEqu];
 
     delegate_ = [[MenuItemDelegate alloc] initWithMenuItem:this];
     [menu_item_ setTarget:delegate_];
@@ -109,6 +116,7 @@ void MenuItem::SetTooltip(const std::string& tooltip) {
   [menu_item_ setToolTip:[NSString stringWithUTF8String:tooltip.c_str()]];
 }
 
+    
 void MenuItem::SetEnabled(bool enabled) {
   [menu_item_ setEnabled:enabled];
 }


### PR DESCRIPTION
As described in Issue #367, added basic keyboard shortcut handeling to MenuItems on OS X.

Usage:

``` js
new gui.MenuItem({
   label: 'Test 1',
   shortcut : '\u0008', //  ⌘⌫ 
   click: function() {
     alert(this.label);
   }
});
```

The `shortcut` option will be directly used as a `keyEquivalent` thus will allow everything described [here](https://developer.apple.com/library/mac/documentation/cocoa/Reference/ApplicationKit/Classes/NSMenuItem_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMenuItem/setKeyEquivalent:):

> This method considers the case of the letter passed to determine if it has a Shift modifier added. That is, `[item setKeyEquivalent:@"w"]` sets the key equivalent to `⌘W`, while `[item setKeyEquivalent:@"W"]` is `⌘⇧W`.
> [...]
> If you want to specify the Backspace key as the key equivalent for a menu item, use a single character string with `NSBackspaceCharacter` (defined in NSText.h as 0x08) and for the Forward Delete key, use `NSDeleteCharacter` (defined in NSText.h as 0x7F). Note that these are not the same characters you get from an `NSEvent` key-down event when pressing those keys.

With this API is not possible to define a custom `KeyEquivalentModifierMask`. 
