### PR TITLE
osx icon badge support - setBadgeLabel

### DIFF
--- a/src/api/window/window.cc
+++ b/src/api/window/window.cc
@@ -257,6 +257,10 @@ void Window::Call(const std::string& method,
     bool flash;
     if (arguments.GetBoolean(0, &flash))
       shell_->window()->FlashFrame(flash);
+  } else if (method == "SetBadgeLabel") {
+    std::string label;
+    if (arguments.GetString(0, &label))
+      shell_->window()->SetBadgeLabel(label);
   } else if (method == "SetMenu") {
     int id;
     if (arguments.GetInteger(0, &id))

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -405,6 +405,11 @@ Window.prototype.requestAttention = function(flash) {
   CallObjectMethod(this, 'RequestAttention', [ flash ]);
 }
 
+Window.prototype.setBadgeLabel = function(label) {
+  label = "" + label;
+  CallObjectMethod(this, 'SetBadgeLabel', [ label ]);
+}
+
 Window.prototype.setPosition = function(position) {
   if (position != 'center' && position != 'mouse')
     throw new String('Invalid postion');

--- a/src/browser/native_window.h
+++ b/src/browser/native_window.h
@@ -92,6 +92,7 @@ class NativeWindow {
   virtual gfx::Point GetPosition() = 0;
   virtual void SetTitle(const std::string& title) = 0;
   virtual void FlashFrame(bool flash) = 0;
+  virtual void SetBadgeLabel(const std::string& badge) = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual void SetMenu(nwapi::Menu* menu) = 0;

--- a/src/browser/native_window_gtk.cc
+++ b/src/browser/native_window_gtk.cc
@@ -295,6 +295,10 @@ void NativeWindowGtk::FlashFrame(bool flash) {
   gtk_window_set_urgency_hint(window_, flash);
 }
 
+void NativeWindowGtk::SetBadgeLabel(const std::string& badge) {
+  // TODO
+}
+
 void NativeWindowGtk::SetKiosk(bool kiosk) {
   SetFullscreen(kiosk);
 }

--- a/src/browser/native_window_mac.h
+++ b/src/browser/native_window_mac.h
@@ -64,6 +64,7 @@ class NativeWindowCocoa : public NativeWindow {
   virtual gfx::Point GetPosition() OVERRIDE;
   virtual void SetTitle(const std::string& title) OVERRIDE;
   virtual void FlashFrame(bool flash) OVERRIDE;
+  virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;

--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -643,6 +643,10 @@ void NativeWindowCocoa::FlashFrame(bool flash) {
   }
 }
 
+void NativeWindowCocoa::SetBadgeLabel(const std::string& badge) {
+  [[NSApp dockTile] setBadgeLabel:base::SysUTF8ToNSString(badge)];
+}
+
 void NativeWindowCocoa::SetKiosk(bool kiosk) {
   if (kiosk) {
     NSApplicationPresentationOptions options =

--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -457,6 +457,10 @@ void NativeWindowWin::FlashFrame(bool flash) {
   window_->FlashFrame(flash);
 }
 
+void NativeWindowWin::SetBadgeLabel(const std::string& badge) {
+  // TODO
+}
+
 void NativeWindowWin::SetKiosk(bool kiosk) {
   SetFullscreen(kiosk);
 }

--- a/src/browser/native_window_win.h
+++ b/src/browser/native_window_win.h
@@ -77,6 +77,7 @@ class NativeWindowWin : public NativeWindow,
   virtual void SetTitle(const std::string& title) OVERRIDE;
   virtual void FlashFrame(bool flash) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
+  virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;
   virtual void SetToolbarButtonEnabled(TOOLBAR_BUTTON button,


### PR DESCRIPTION
osx is supported only, I'm not sure is there way to implement on other platforms

``` js
var gui = require('nw.gui'); 
var win = gui.Window.get();
win.setBadgeLabel("3");
```

![image](https://f.cloud.github.com/assets/880901/2471880/1af7d3fc-b02d-11e3-841a-daa28609fd4c.png)
