### PR TITLE
Fixing inaccurate warning logging when accessing properties on windows.

### DIFF
--- a/src/api/dispatcher_host.cc
+++ b/src/api/dispatcher_host.cc
@@ -193,12 +193,13 @@ void DispatcherHost::OnCallObjectMethodSync(
              << " arguments:" << arguments;
 
   Base* object = GetApiObject(object_id);
-  LOG(WARNING) << "Unknown object: " << object_id
+  if (object)
+    object->CallSync(method, arguments, result);
+  else
+    DLOG(WARNING) << "Unknown object: " << object_id
              << " type:" << type
              << " method:" << method
              << " arguments:" << arguments;
-  if (object)
-    object->CallSync(method, arguments, result);
 }
 
 void DispatcherHost::OnCallStaticMethod(


### PR DESCRIPTION
Was getting spammed with all these logs in the terminal:
[24098:0402/164715:WARNING:dispatcher_host.cc(196)] Unknown object: 1 type:Window method:ShowDevTools arguments:[ "", false ]
[24098:0402/164727:WARNING:dispatcher_host.cc(196)] Unknown object: 2 type:Window method:GetPosition arguments:[  ]
[24098:0402/164727:WARNING:dispatcher_host.cc(196)] Unknown object: 2 type:Window method:GetPosition arguments:[  ]
[24098:0402/164727:WARNING:dispatcher_host.cc(196)] Unknown object: 2 type:Window method:GetSize arguments:[  ]
[24098:0402/164727:WARNING:dispatcher_host.cc(196)] Unknown object: 2 type:Window method:GetSize arguments:[  ]

Fixed this by borrowing the same flow as DispatcherHost::OnCallObjectMethod (line 178).
