### PR TITLE
Make linux_dump_symbols default to be 1

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -7,7 +7,7 @@
     'nw_product_name': 'node-webkit',
     'conditions': [
       ['OS=="linux"', {
-       'linux_dump_symbols%': 1,
+       'linux_dump_symbols': 1,
       }],
     ],
   },


### PR DESCRIPTION
The linux_dump_sybols is set to 0 in common.gypi:1033, so the default
value in nw.gypi will be ignored anyways. Removing the % could make this
option valid.
