### PR TITLE
#1350: fix maximize/restore/fullscreen cause hidden window to be visible on windows platform

### DIFF
--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -302,7 +302,7 @@ void NativeWindowWin::Show() {
   VLOG(1) << "NativeWindowWin::Show(); initial_focus = " << initial_focus_;
   if (is_maximized_)
     window_->native_widget_private()->ShowWithWindowState(ui::SHOW_STATE_MAXIMIZED);
-  if (is_minimized_)
+  else if (is_minimized_)
     window_->native_widget_private()->ShowWithWindowState(ui::SHOW_STATE_MINIMIZED);
   else if (!initial_focus_) {
     window_->set_focus_on_creation(false);


### PR DESCRIPTION
you can use package.json in the issue page, and my test code like this:

```HTML
<html>
  <body>
    <script>
      var gui = require('nw.gui');
      var win = gui.Window.get();
	  test_maximize(win);
      setTimeout(function () {
        win.show();
      }, 5000);
	  
	  function test_maximize(win) {
        win.maximize();
	  }
	  function test_minimize(win) {
        win.minimize();
	  }
	  function test_restore(win) {
        win.restore();
	  }
	  function test_fullscreen(win) {
        win.enterFullscreen();
	  }
	  function test_maximize_minimize(win) {
        win.maximize();
        win.minimize();
	  }
	  function test_maximize_restore(win) {
        win.maximize();
        win.restore();
	  }
	  function test_maximize_fullscreen(win) {
        win.maximize();
        win.enterFullscreen();
	  }
	  function test_maximize_minimize_restore(win) {
        win.maximize();
        win.minimize();
        win.restore();
	  }
	  function test_maximize_restore_minimize(win) {
        win.maximize();
        win.restore();
        win.minimize();
	  }
    </script>
  </body>
</html>
```