### PR TITLE
Updated symbol generation and strip process.

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -563,22 +563,25 @@
       ],
     },
     {
-      'target_name': 'nw_symbols',
+      'target_name': 'nw_strip_symbol',
       'type': 'none',
       'conditions': [
         ['OS=="linux"', {
+          'variables': {
+            'linux_strip_binary': 1,
+          },
           'actions': [
             {
-              'action_name': 'dump_symbols',
+              'action_name': 'dump_symbol_and_strip',
               'inputs': [
-                '<(DEPTH)/build/linux/dump_app_syms',
+                '<(DEPTH)/content/nw/tools/dump_app_syms',
                 '<(PRODUCT_DIR)/dump_syms',
                 '<(PRODUCT_DIR)/nw',
               ],
               'outputs': [
                 '<(PRODUCT_DIR)/nw.breakpad.<(target_arch)',
               ],
-              'action': ['<(DEPTH)/build/linux/dump_app_syms',
+              'action': ['<(DEPTH)/content/nw/tools/dump_app_syms',
                          '<(PRODUCT_DIR)/dump_syms',
                          '<(linux_strip_binary)',
                          '<(PRODUCT_DIR)/nw',
@@ -595,7 +598,7 @@
       ],
     },
     {
-      'target_name': 'strip',
+      'target_name': 'strip_binaries',
       'type': 'none',
       'conditions': [
         ['OS=="linux"', {
@@ -603,21 +606,22 @@
             {
               'action_name': 'strip_nw_binaries',
               'inputs': [
-                '<(PRODUCT_DIR)/nw',
+                '<(PRODUCT_DIR)/nwsnapshot',
+                '<(PRODUCT_DIR)/chromedriver',
               ],
               'outputs': [
-                '<(PRODUCT_DIR)/strip_nw.stamp',
+                '<(PRODUCT_DIR)/strip_binaries.stamp',
               ],
-              'action': ['sh', '<(DEPTH)/content/nw/tools/strip.sh',
-                         '<@(_outputs)',
+              'action': ['strip',
                          '<@(_inputs)'],
-              'message': 'Stripping release executable',
+              'message': 'Stripping release binaries',
             },
           ],
+          'dependencies': [
+             '<(DEPTH)/v8/tools/gyp/v8.gyp:nwsnapshot',
+             '<(DEPTH)/chrome/chrome.gyp:chromedriver',
+          ],
         }],
-      ],
-      'dependencies': [
-        'nw_symbols',
       ],
     },
     {
@@ -640,12 +644,12 @@
       ],
       'dependencies': [
         '<(DEPTH)/chrome/chrome.gyp:chromedriver',
-        'nw_symbols',
+        'nw_strip_symbol',
       ],
       'conditions': [
         ['OS == "linux"', {
           'dependencies': [
-            'strip',
+            'strip_binaries',
           ],
         }],
       ],
@@ -960,3 +964,4 @@
     }],  # OS=="mac"
   ] # conditions
 }
+

--- a/tools/dump_app_syms
+++ b/tools/dump_app_syms
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Copyright (c) 2010 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Helper script to run dump_syms on Chrome Linux executables and strip
+# them if needed.
+
+set -e
+
+usage() {
+  echo -n "$0 <dump_syms_exe> <strip_binary> " >&2
+  echo "<binary_with_symbols> <symbols_output>" >&2
+}
+
+
+if [ $# -ne 4 ]; then
+  usage
+  exit 1
+fi
+
+SCRIPTDIR="$(readlink -f "$(dirname "$0")")"
+DUMPSYMS="$1"
+STRIP_BINARY="$2"
+INFILE="$3"
+OUTFILE="$4"
+
+# Dump the symbols from the given binary.
+if [ ! -e "$OUTFILE" -o "$INFILE" -nt "$OUTFILE" ]; then
+echo "bb"
+  "$DUMPSYMS" -r "$INFILE" > "$OUTFILE"
+fi
+
+if [ "$STRIP_BINARY" != "0" ]; then
+  strip "$INFILE"
+# To avoid dumpping twice.
+echo "aa"
+  touch "$OUTFILE"
+fi
+
+
+

--- a/tools/strip.sh
+++ b/tools/strip.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-touch -r $2 $1
-strip $2
-touch -r $1 $2


### PR DESCRIPTION
Use the upstream's script (with a minor fix) to generate symbol and
strip nw binary in the mean time.
Since everything is built under '-g' (common.gyp:linux_dump_symbols=1),
the chromedriver and nwsnapshot should also be stripped.
