### PR TITLE
Mac menu items show package.json `name`, but this string is not for humans

### DIFF
--- a/src/browser/app_controller_mac.mm
+++ b/src/browser/app_controller_mac.mm
@@ -67,7 +67,7 @@
   [[NSApp mainMenu] addItem:[[[NSMenuItem alloc]
       initWithTitle:@"" action:nil keyEquivalent:@""] autorelease]];
   nw::StandardMenusMac standard_menus(
-      browser_client->shell_browser_main_parts()->package()->GetName());
+      browser_client->shell_browser_main_parts()->package()->GetTitle());
   standard_menus.BuildAppleMenu();
   if (!no_edit_menu)
     standard_menus.BuildEditMenu();

--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -675,7 +675,7 @@ void NativeWindowCocoa::SetMenu(nwapi::Menu* menu) {
   bool no_edit_menu = false;
   shell_->GetPackage()->root()->GetBoolean("no-edit-menu", &no_edit_menu);
 
-  StandardMenusMac standard_menus(shell_->GetPackage()->GetName());
+  StandardMenusMac standard_menus(shell_->GetPackage()->GetTitle());
   [NSApp setMainMenu:menu->menu_];
   standard_menus.BuildAppleMenu();
   if (!no_edit_menu)

--- a/src/browser/standard_menus_mac.h
+++ b/src/browser/standard_menus_mac.h
@@ -29,7 +29,7 @@ namespace nw {
 
 class StandardMenusMac {
  public:
-  StandardMenusMac(const std::string& app_name);
+  StandardMenusMac(const std::string& app_title);
   ~StandardMenusMac();
 
   void BuildAppleMenu();
@@ -37,7 +37,7 @@ class StandardMenusMac {
   void BuildWindowMenu();
 
  private:
-  std::string app_name_;
+  std::string app_title_;
 
   DISALLOW_COPY_AND_ASSIGN(StandardMenusMac);
 };

--- a/src/browser/standard_menus_mac.mm
+++ b/src/browser/standard_menus_mac.mm
@@ -37,8 +37,15 @@
 
 namespace nw {
 
-StandardMenusMac::StandardMenusMac(const std::string& app_name)
-    : app_name_(app_name) {
+StandardMenusMac::StandardMenusMac(const std::string& app_title)
+    : app_title_(app_title) {
+  if (app_title_.size() == 0 || app_title_ == "node-webkit") {
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    NSString *bundleName = [mainBundle objectForInfoDictionaryKey:@"CFBundleName"];
+    if (bundleName) {
+      app_title_ = [bundleName UTF8String];
+    }
+  }
 }
 
 StandardMenusMac::~StandardMenusMac() {
@@ -47,7 +54,7 @@ StandardMenusMac::~StandardMenusMac() {
 void StandardMenusMac::BuildAppleMenu() {
   NSMenu* appleMenu = [[NSMenu alloc] initWithTitle:@""];
 
-  string16 name = base::UTF8ToUTF16(app_name_);
+  string16 name = base::UTF8ToUTF16(app_title_);
   [appleMenu addItemWithTitle:l10n_util::GetNSStringFWithFixup(IDS_ABOUT_MAC, name)
                        action:@selector(orderFrontStandardAboutPanel:)
                 keyEquivalent:@""];

--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -234,6 +234,16 @@ std::string Package::GetName() {
   return name;
 }
 
+std::string Package::GetTitle() {
+  std::string title("node-webkit");
+  root()->GetString(switches::kmName, &title);
+  base::DictionaryValue* window_manifest = window();
+  if (window_manifest) {
+      window_manifest->GetString(switches::kmTitle, &title);
+  }
+  return title;
+}
+
 bool Package::GetUseNode() {
   bool use_node = true;
   root()->GetBoolean(switches::kNodejs, &use_node);

--- a/src/nw_package.h
+++ b/src/nw_package.h
@@ -63,6 +63,9 @@ class Package {
   // Get app's name.
   std::string GetName();
 
+  // Get app's main window title, defaulting to the name.
+  std::string GetTitle();
+
   // Return if we enable node.js.
   bool GetUseNode();
 


### PR DESCRIPTION
The documentation for the manifest format says the `name` field in must be a logical identifier - no spaces, globally unique, etc. Accordingly, I set my `package.json` `name` to `com.yukkurigames.pwl6`, and the `window` `title` to the intended human-readable name for the application. But on OS X node-webkit uses the `name` field to fill in the Mac title menu.

(My plist `CFBundleIdentifier` is also `com.yukkurigames.pwl6`, and `CFBundleName` and `CFBundleDisplayName` are the full title. The title appears correctly everywhere else, e.g. the About dialog, the task switcher, the dock.)

![screen shot 2014-05-06 at 1 06 58](https://cloud.githubusercontent.com/assets/1330897/2884402/19f00046-d4aa-11e3-966d-465ad7b49b73.png)

Either the menu should take the string of the default window title, or there should be another field in `package.json` for the name used in the menu.
