### PR TITLE
Add support for Window.SetIcon(icon) (win + gtk only)

### DIFF
--- a/src/api/window/window.cc
+++ b/src/api/window/window.cc
@@ -269,6 +269,10 @@ void Window::Call(const std::string& method,
     int type;
     if (arguments.GetInteger(0, &type))
       shell_->Reload(static_cast<content::Shell::ReloadType>(type));
+  } else if (method == "SetIcon") {
+	std::string icon_path;
+	if (arguments.GetString(0, &icon_path))
+	  shell_->window()->SetIcon(icon_path);
   } else if (method == "CapturePage") {
     std::string image_format_str;
     if (arguments.GetString(0, &image_format_str))

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -428,6 +428,10 @@ Window.prototype.reloadIgnoringCache = function() {
   this.reload(1);
 }
 
+Window.prototype.setIcon = function(icon) {
+  CallObjectMethod(this, 'SetIcon', [ icon ]);
+}
+
 Window.prototype.reloadOriginalRequestURL = function() {
   this.reload(2);
 }

--- a/src/browser/native_window.cc
+++ b/src/browser/native_window.cc
@@ -167,4 +167,8 @@ void NativeWindow::LoadAppIconFromPackage(base::DictionaryValue* manifest) {
   }
 }
 
+void NativeWindow::LoadAppIcon(std::string icon_path) {
+    shell_->GetPackage()->GetImage(FilePath::FromUTF8Unsafe(icon_path), &app_icon_);
+}
+
 }  // namespace nw

--- a/src/browser/native_window.h
+++ b/src/browser/native_window.h
@@ -98,6 +98,7 @@ class NativeWindow {
   virtual void SetMenu(nwapi::Menu* menu) = 0;
   virtual void SetInitialFocus(bool accept_focus) = 0;
   virtual bool InitialFocus() = 0;
+  virtual void SetIcon(std::string icon_path) = 0;
 
   // Toolbar related controls.
   enum TOOLBAR_BUTTON {
@@ -139,6 +140,7 @@ class NativeWindow {
 
   // Icon showed in the task bar.
   gfx::Image app_icon_;
+  void LoadAppIcon(std::string icon_path);
 
   scoped_refptr<CapturePageHelper> capture_page_helper_;
   friend class content::Shell;

--- a/src/browser/native_window_gtk.cc
+++ b/src/browser/native_window_gtk.cc
@@ -320,6 +320,13 @@ void NativeWindowGtk::SetInitialFocus(bool initial_focus) {
   gtk_window_set_focus_on_map(GTK_WINDOW(window_), initial_focus);
 }
 
+void NativeWindowGtk::SetIcon(std::string icon_path) {
+  LoadAppIcon(icon_path);
+
+  if (!app_icon().IsEmpty())
+    gtk_window_set_icon(window_, app_icon().ToGdkPixbuf());
+}
+
 bool NativeWindowGtk::InitialFocus() {
   return gtk_window_get_focus_on_map(GTK_WINDOW(window_));
 }

--- a/src/browser/native_window_gtk.h
+++ b/src/browser/native_window_gtk.h
@@ -65,6 +65,7 @@ class NativeWindowGtk : public NativeWindow {
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;
   virtual void SetInitialFocus(bool initial_focus) OVERRIDE;
+  virtual void SetIcon(std::string icon_path) OVERRIDE;
   virtual bool InitialFocus() OVERRIDE;
   virtual void SetToolbarButtonEnabled(TOOLBAR_BUTTON button,
                                        bool enabled) OVERRIDE;

--- a/src/browser/native_window_mac.h
+++ b/src/browser/native_window_mac.h
@@ -74,6 +74,7 @@ class NativeWindowCocoa : public NativeWindow {
   virtual void SetToolbarIsLoading(bool loading) OVERRIDE;
   virtual void SetInitialFocus(bool accept_focus) OVERRIDE;
   virtual bool InitialFocus() OVERRIDE;
+  virtual void SetIcon(std::string icon_path) OVERRIDE;
 
   // Called to handle a mouse event.
   void HandleMouseEvent(NSEvent* event);

--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -687,6 +687,10 @@ void NativeWindowCocoa::SetInitialFocus(bool accept_focus) {
   initial_focus_ = accept_focus;
 }
 
+void NativeWindowCocoa::SetIcon(std::string icon_path) {
+  // Not implemented on Mac
+}
+
 bool NativeWindowCocoa::InitialFocus() {
   return initial_focus_;
 }

--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -706,6 +706,11 @@ void NativeWindowWin::SetInitialFocus(bool initial_focus) {
   initial_focus_ = initial_focus;
 }
 
+void NativeWindowWin::SetIcon(std::string icon_path) {
+  LoadAppIcon(icon_path);
+  window_->UpdateWindowIcon();
+}
+
 bool NativeWindowWin::ExecuteWindowsCommand(int command_id) {
   // Windows uses the 4 lower order bits of |command_id| for type-specific
   // information so we must exclude this when comparing.

--- a/src/browser/native_window_win.h
+++ b/src/browser/native_window_win.h
@@ -91,6 +91,7 @@ class NativeWindowWin : public NativeWindow,
   virtual void SetToolbarIsLoading(bool loading) OVERRIDE;
   virtual void SetInitialFocus(bool initial_focus) OVERRIDE;
   virtual bool InitialFocus() OVERRIDE { return initial_focus_; }
+  virtual void SetIcon(std::string icon_path) OVERRIDE;
 
   // WidgetDelegate implementation.
   virtual void OnWidgetMove() OVERRIDE;


### PR DESCRIPTION
Hi!

I had a use-case where I wanted to be able to dynamically change the app icon at runtime.  This patch supports the functionality.

Tested on win32 only
Should support GTK (it's a very simple patch)
MacOS doesn't seem to support setting the icon at all (even from package.json) so it's left as a no-op there.

Thanks for reviewing this!