### PR TITLE
webkit desktop notification

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -315,6 +315,14 @@
         'src/renderer/shell_render_process_observer.h',
         'src/nw_shell.cc',
         'src/nw_shell.h',
+        'src/nw_notification_manager.h',
+        'src/nw_notification_manager.cc',
+        'src/nw_notification_manager_win.h',
+        'src/nw_notification_manager_win.cc',		
+        'src/nw_notification_manager_mac.h',
+        'src/nw_notification_manager_mac.mm',
+        'src/nw_notification_manager_linux.h',
+        'src/nw_notification_manager_linux.cc',
         'src/shell_browser_context.cc',
         'src/shell_browser_context.h',
         'src/shell_browser_main.cc',
@@ -833,6 +841,11 @@
             '<(DEPTH)/build/linux/system.gyp:gtk',
           ],
         }],  # toolkit_uses_gtk
+        ['OS=="linux"', {
+          'dependencies': [
+            '<(DEPTH)/build/linux/system.gyp:notify',
+          ],
+        }],  # OS=="linux"
         ['OS=="mac"', {
           'product_name': '<(nw_product_name)',
           'dependencies!': [

--- a/src/api/tray/tray_win.cc
+++ b/src/api/tray/tray_win.cc
@@ -56,7 +56,7 @@ class TrayObserver : public StatusIconObserver {
 
 void Tray::Create(const base::DictionaryValue& option) {
   if (!status_tray_)
-    status_tray_ = StatusTray::Create();
+    status_tray_ = StatusTray::GetSingleton();
 
   status_icon_ = status_tray_->CreateStatusIcon(StatusTray::NOTIFICATION_TRAY_ICON,
                                                 gfx::ImageSkia(), base::string16());

--- a/src/nw_notification_manager.cc
+++ b/src/nw_notification_manager.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "ui/gfx/image/image.h"
+#include "content/public/browser/render_view_host.h"
+
+#include "content/nw/src/nw_notification_manager.h"
+#if defined(OS_MACOSX)
+#include "content/nw/src/nw_notification_manager_mac.h"
+#elif defined(OS_WIN)
+#include "content/nw/src/nw_notification_manager_win.h"
+#elif defined(OS_LINUX)
+#include "content/nw/src/nw_notification_manager_linux.h"
+#endif
+
+namespace nw
+{
+NotificationManager* NotificationManager::singleton_ = NULL;
+
+NotificationManager::NotificationManager() {
+}
+
+NotificationManager::~NotificationManager() {
+  singleton_ = NULL;
+}
+
+NotificationManager* NotificationManager::getSingleton() {
+  if (singleton_ == NULL) {
+#if defined(OS_MACOSX)
+    singleton_ = new NotificationManagerMac();
+#elif defined(OS_WIN)
+    singleton_ = new NotificationManagerWin();
+#elif defined(OS_LINUX)
+    singleton_ = new NotificationManagerLinux();
+#endif
+  }
+  return singleton_;
+}
+
+
+void NotificationManager::ImageDownloadCallback(int id, int http_status, const GURL& image_url, const std::vector<SkBitmap>& bitmaps, const std::vector<gfx::Size>& size) {
+  NotificationManager *singleton = getSingleton();
+  DesktopNotificationParams params = singleton->desktop_notification_params_[id];
+  singleton->AddDesktopNotification(params.params_, params.render_process_id_, params.render_view_id_, params.worker_, &bitmaps);
+  singleton->desktop_notification_params_.erase(id);
+}
+
+bool NotificationManager::AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+  const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) {
+  NOTIMPLEMENTED();
+  return false;
+}
+
+bool NotificationManager::DesktopNotificationPostClick(int render_process_id, int render_view_id, int notification_id) {
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  host->DesktopNotificationPostClick(notification_id);
+  return true;
+}
+
+bool NotificationManager::DesktopNotificationPostClose(int render_process_id, int render_view_id, int notification_id, bool by_user) {
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  host->DesktopNotificationPostClose(notification_id, by_user);
+  return true;
+}
+
+bool NotificationManager::DesktopNotificationPostDisplay(int render_process_id, int render_view_id, int notification_id) {
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  host->DesktopNotificationPostDisplay(notification_id);
+  return true;
+}
+
+bool NotificationManager::DesktopNotificationPostError(int render_process_id, int render_view_id, int notification_id, const base::string16& message) {
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  host->DesktopNotificationPostError(notification_id, message);
+  return true;
+}
+} // namespace nw

--- a/src/nw_notification_manager.h
+++ b/src/nw_notification_manager.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef CONTENT_NW_NOTIFICATION_MANAGER_H_
+#define CONTENT_NW_NOTIFICATION_MANAGER_H_
+
+#include "base/basictypes.h"
+#include "content/public/common/show_desktop_notification_params.h"
+
+namespace nw {
+
+class NotificationManager{
+private:
+  static NotificationManager *singleton_;
+
+protected:
+  explicit NotificationManager();
+
+  // icon image download callback
+  static void ImageDownloadCallback(int id, int http_status, const GURL& image_url, const std::vector<SkBitmap>& bitmaps, const std::vector<gfx::Size>& size);
+  struct DesktopNotificationParams {
+    content::ShowDesktopNotificationHostMsgParams params_;
+    int render_process_id_;
+    int render_view_id_;
+    bool worker_;
+  };
+
+  // map used to stored desktop notification params used by ImageDownloadCallback
+  std::map<int, DesktopNotificationParams> desktop_notification_params_;
+
+  // internal function for AddDesktopNotification
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps);
+
+public:
+  virtual ~NotificationManager();
+  static NotificationManager* getSingleton();
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker) = 0;
+  virtual bool CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) = 0;
+
+  bool DesktopNotificationPostClick(int render_process_id, int render_view_id, int notification_id);
+  bool DesktopNotificationPostClose(int render_process_id, int render_view_id, int notification_id, bool by_user);
+  bool DesktopNotificationPostDisplay(int render_process_id, int render_view_id, int notification_id);
+  bool DesktopNotificationPostError(int render_process_id, int render_view_id, int notification_id, const base::string16& message);
+
+};
+
+} // namespace nw
+
+#endif // CONTENT_NW_NOTIFICATION_MANAGER_H_

--- a/src/nw_notification_manager_linux.cc
+++ b/src/nw_notification_manager_linux.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "chrome/browser/status_icons/status_icon.h"
+
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/nw/src/browser/native_window.h"
+#include "content/nw/src/nw_package.h"
+#include "content/nw/src/nw_shell.h"
+
+#include "ui/gfx/image/image.h"
+#include "base/strings/utf_string_conversions.h"
+
+#include "content/nw/src/nw_notification_manager_linux.h"
+
+#include "ui/gfx/gtk_util.h"
+
+//#define GET_NOTIFICATION(id) mNotificationIDmap.find(id)
+//Ubuntu notify-osd can only show 1 notification, this is the "hack" to do that
+#define GET_NOTIFICATION(id) mNotificationIDmap.begin()
+
+namespace nw {
+
+NotificationManagerLinux::NotificationManagerLinux() {
+  notify_init (content::Shell::GetPackage()->GetName().c_str());
+}
+
+NotificationManagerLinux::~NotificationManagerLinux() {
+  notify_uninit();
+}
+
+void NotificationManagerLinux::onClose(NotifyNotification *notif)
+{
+  NotificationManagerLinux* singleton = static_cast<NotificationManagerLinux*>(NotificationManagerLinux::getSingleton());
+  std::map<int, NotifyNotification*>::iterator i;
+  for (i = singleton->mNotificationIDmap.begin(); i!=singleton->mNotificationIDmap.end(); i++) {
+    if (i->second == notif)
+    	break;
+  }
+  singleton->mNotificationIDmap.erase(i);
+  g_object_unref(G_OBJECT(notif));
+};
+
+bool NotificationManagerLinux::AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+  const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) {
+
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  content::Shell* shell = content::Shell::FromRenderViewHost(host);
+
+  if (bitmaps == NULL) {
+    // called from public function, save the params
+    DesktopNotificationParams desktop_notification_params;
+    desktop_notification_params.params_ = params;
+    desktop_notification_params.render_process_id_ = render_process_id;
+    desktop_notification_params.render_view_id_ = render_view_id;
+
+    // download the icon image first
+    content::WebContents::ImageDownloadCallback imageDownloadCallback = base::Bind(&NotificationManager::ImageDownloadCallback);
+    int id = shell->web_contents()->DownloadImage(params.icon_url, true, 0, imageDownloadCallback);
+    desktop_notification_params_[id] = desktop_notification_params;
+
+    // wait for the image download callback
+    return true;
+  }
+
+  // if we reach here, it means the function is called from image download callback
+
+  SkBitmap bitmap;
+  // try to get the notification icon image given by image download callback
+  if (bitmaps->size())
+    bitmap = bitmaps->at(0);
+  else {
+	// set the default notification icon as the app icon
+	bitmap = shell->window()->app_icon().AsBitmap();
+  }
+
+  NotifyNotification * notif;
+  std::map<int, NotifyNotification*>::iterator i = GET_NOTIFICATION(params.notification_id);
+  if (i==mNotificationIDmap.end()) {
+    notif = notify_notification_new (
+      base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL);
+    mNotificationIDmap[params.notification_id] = notif;
+  }
+  else {
+    notif = i->second;
+    notify_notification_update(notif, base::UTF16ToUTF8(params.title).c_str(),
+      base::UTF16ToUTF8(params.body).c_str(), NULL);
+  }
+
+  GdkPixbuf* pixbuf = gfx::GdkPixbufFromSkBitmap(bitmap);
+  notify_notification_set_image_from_pixbuf(notif, pixbuf);
+  g_object_unref(pixbuf);
+
+  NOTIFY_NOTIFICATION_GET_CLASS(notif)->closed = onClose;
+
+  GError* error = NULL;
+  if (notify_notification_show (notif, &error)) {
+    DesktopNotificationPostDisplay(render_process_id, render_view_id, params.notification_id);
+  }
+  else {
+    base::string16 errorMsg = base::UTF8ToUTF16(error->message);
+    DesktopNotificationPostError(render_process_id, render_view_id, params.notification_id, errorMsg);
+  }
+  return error==NULL;
+}
+
+bool NotificationManagerLinux::CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) {
+  std::map<int, NotifyNotification*>::const_iterator i = GET_NOTIFICATION(notification_id);
+  if (i!=mNotificationIDmap.end()) {
+    return notify_notification_close(i->second, NULL);
+  }
+  return false;
+}
+} // namespace nw

--- a/src/nw_notification_manager_linux.h
+++ b/src/nw_notification_manager_linux.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef CONTENT_NW_NOTIFICATION_MANAGER_LINUX_H_
+#define CONTENT_NW_NOTIFICATION_MANAGER_LINUX_H_
+
+#include "content/nw/src/nw_notification_manager.h"
+#include <libnotify/notify.h>
+
+namespace nw {
+class NotificationManagerLinux : public NotificationManager {
+
+  std::map<int, NotifyNotification*>  mNotificationIDmap;
+  static void onClose(NotifyNotification *notif);
+
+
+  // internal function for AddDesktopNotification
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) OVERRIDE;
+
+public:
+  explicit NotificationManagerLinux();
+  virtual ~NotificationManagerLinux();
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker) OVERRIDE {
+    return AddDesktopNotification(params, render_process_id, render_view_id, worker, NULL);
+  }
+  virtual bool CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) OVERRIDE;
+};
+
+} // namespace nw
+
+#endif // CONTENT_NW_NOTIFICATION_MANAGER_LINUX_H_

--- a/src/nw_notification_manager_mac.h
+++ b/src/nw_notification_manager_mac.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef CONTENT_NW_NOTIFICATION_MANAGER_MAC_H_
+#define CONTENT_NW_NOTIFICATION_MANAGER_MAC_H_
+
+#include "content/nw/src/nw_notification_manager.h"
+
+namespace nw {
+
+class NotificationManagerMac : public NotificationManager {
+
+  // internal function for AddDesktopNotification
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+  const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) OVERRIDE;
+
+public:
+  explicit NotificationManagerMac();
+  virtual ~NotificationManagerMac(){}
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker) OVERRIDE;
+  virtual bool CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) OVERRIDE;
+
+};
+
+} // namespace nw
+
+#endif // CONTENT_NW_NOTIFICATION_MANAGER_MAC_H_

--- a/src/nw_notification_manager_mac.mm
+++ b/src/nw_notification_manager_mac.mm
@@ -1,0 +1,156 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Cocoa/Cocoa.h>
+#include "base/mac/mac_util.h"
+#include "base/strings/sys_string_conversions.h"
+
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/nw/src/browser/native_window.h"
+#include "content/nw/src/nw_package.h"
+#include "content/nw/src/nw_shell.h"
+
+#include "content/nw/src/nw_notification_manager_mac.h"
+
+#if !defined(MAC_OS_X_VERSION_10_8) || \
+    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_8
+@interface NSUserNotificationCenter : NSObject
+@end
+@interface NSUserNotification : NSObject
+@end
+@implementation NSUserNotification
+@end
+#endif
+
+@interface NWUserNotificationCenterDelegate : NSObject<NSUserNotificationCenterDelegate> {
+}
+@end
+@implementation NWUserNotificationCenterDelegate
+
+static NWUserNotificationCenterDelegate *singleton_ = nil;
+
++(NWUserNotificationCenterDelegate *)defaultNWUserNotificationCenterDelegate{
+  @synchronized(self) {
+    if (singleton_ == nil)
+      singleton_ = [[self alloc] init];
+  }
+  return singleton_;
+}
+
+-(BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
+  shouldPresentNotification : (NSUserNotification *)notification {
+
+  NSNumber *render_process_id = [notification.userInfo objectForKey : @"render_process_id"];
+  NSNumber *render_view_id = [notification.userInfo objectForKey : @"render_view_id"];
+  NSNumber *notification_id = [notification.userInfo objectForKey : @"notification_id"];
+
+  nw::NotificationManager::getSingleton()->DesktopNotificationPostDisplay(render_process_id.intValue,
+      render_view_id.intValue,
+      notification_id.intValue);
+  return YES;
+}
+
+-(void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification : (NSUserNotification *)notification {
+  NSNumber *render_process_id = [notification.userInfo objectForKey : @"render_process_id"];
+  NSNumber *render_view_id = [notification.userInfo objectForKey : @"render_view_id"];
+  NSNumber *notification_id = [notification.userInfo objectForKey : @"notification_id"];
+
+  nw::NotificationManager::getSingleton()->DesktopNotificationPostClick(render_process_id.intValue,
+    render_view_id.intValue,
+    notification_id.intValue);
+}
+@end
+
+namespace nw {
+NotificationManagerMac::NotificationManagerMac() {
+}
+
+bool NotificationManagerMac::AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams &params, const int render_process_id, const int render_view_id, const bool worker) {
+  return AddDesktopNotification(params, render_process_id, render_view_id, worker, NULL);
+}
+
+bool NotificationManagerMac::AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+  const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) {
+
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == nullptr)
+    return false;
+  content::Shell* shell = content::Shell::FromRenderViewHost(host);
+
+  static const bool downloadImage = base::mac::IsOSMavericksOrLater();
+
+  if (bitmaps == NULL && downloadImage) {
+    // called from public function, save the params
+    DesktopNotificationParams desktop_notification_params;
+    desktop_notification_params.params_ = params;
+    desktop_notification_params.render_process_id_ = render_process_id;
+    desktop_notification_params.render_view_id_ = render_view_id;
+
+    // download the icon image first
+    content::WebContents::ImageDownloadCallback imageDownloadCallback = base::Bind(&NotificationManager::ImageDownloadCallback);
+    int id = shell->web_contents()->DownloadImage(params.icon_url, true, 0, imageDownloadCallback);
+    desktop_notification_params_[id] = desktop_notification_params;
+
+    // wait for the image download callback
+    return true;
+  }
+
+  // if we reach here, it means the function is called from image download callback
+
+  NSUserNotification *notification = [[NSUserNotification alloc] init];
+  [notification setTitle : base::SysUTF16ToNSString(params.title)];
+  [notification setInformativeText : base::SysUTF16ToNSString(params.body)];
+  notification.hasActionButton = YES;
+
+  if (bitmaps && bitmaps->size()) {
+    // try to get the notification icon image given by image download callback
+    gfx::Image icon = gfx::Image::CreateFrom1xBitmap(bitmaps->at(0));
+
+    // this function only runs on Mavericks or later
+    [notification setContentImage : icon.ToNSImage()];
+  }
+
+  notification.userInfo = @{ @"render_process_id" :[NSNumber numberWithInt : render_process_id],
+    @"render_view_id" :[NSNumber numberWithInt : render_view_id],
+    @"notification_id" :[NSNumber numberWithInt : params.notification_id],
+  };
+
+  [notification setSoundName : @"NSUserNotificationDefaultSoundName"];
+
+  [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[NWUserNotificationCenterDelegate defaultNWUserNotificationCenterDelegate]];
+
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+
+  [notification release];
+
+  return true;
+}
+
+bool NotificationManagerMac::CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id){
+  for (NSUserNotification *notification in[[NSUserNotificationCenter defaultUserNotificationCenter] deliveredNotifications]) {
+    NSNumber *current_notification_id = [notification.userInfo objectForKey : @"notification_id"];
+    if (current_notification_id.intValue == notification_id){
+      [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:notification];
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace nw

--- a/src/nw_notification_manager_win.cc
+++ b/src/nw_notification_manager_win.cc
@@ -1,0 +1,190 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "chrome/browser/status_icons/status_icon.h"
+#include "chrome/browser/status_icons/status_icon_observer.h"
+#include "chrome/browser/ui/views/status_icons/status_tray_win.h"
+
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/nw/src/browser/native_window.h"
+#include "content/nw/src/nw_package.h"
+#include "content/nw/src/nw_shell.h"
+
+#include "ui/gfx/image/image.h"
+#include "base/strings/utf_string_conversions.h"
+
+#include "content/nw/src/nw_notification_manager_win.h"
+
+namespace nw {
+class TrayObserver : public StatusIconObserver {
+public:
+  TrayObserver(NotificationManagerWin* tray)
+    : tray_(tray) {
+  }
+
+  virtual ~TrayObserver() {
+  }
+
+  virtual void OnStatusIconClicked() OVERRIDE {
+  }
+
+  virtual void OnBalloonEvent(int event) OVERRIDE {
+    switch (event) {
+    case NIN_BALLOONHIDE:
+      tray_->DesktopNotificationPostClose(true);
+      tray_->ReleaseNotification();
+      break;
+    case NIN_BALLOONTIMEOUT:
+      tray_->DesktopNotificationPostClose(false);
+      tray_->ReleaseNotification();
+      break;
+    case NIN_BALLOONSHOW:
+      tray_->DesktopNotificationPostDisplay();
+      break;
+    }
+  }
+
+  virtual void OnBalloonClicked() OVERRIDE {
+    tray_->DesktopNotificationPostClick();
+    tray_->ReleaseNotification();
+  }
+private:
+  NotificationManagerWin* tray_;
+};
+
+NotificationManagerWin::NotificationManagerWin() : status_icon_(NULL) {
+  status_tray_ = static_cast<StatusTrayWin*>(StatusTray::GetSingleton());
+
+  // check if status icon is already created
+  StatusIcon* status_icon = status_tray_->GetStatusIcon();
+
+  // if status icon already created, set the notification count to 1 and add the observer
+  notification_count_ = status_icon ? 1 : 0;
+  if (status_icon) {
+    status_observer_ = new TrayObserver(this);
+    status_icon->AddObserver(status_observer_);
+  }
+}
+
+bool NotificationManagerWin::ReleaseNotification() {
+  if (notification_count_ > 0) {
+    if (notification_count_ == 1) {
+      // if I create the status_icon_ I am responsible to delete it
+      if (status_icon_) {
+        status_icon_->RemoveObserver(status_observer_);
+        status_tray_->RemoveStatusIcon(status_icon_);
+        status_icon_ = NULL;
+      }
+
+      delete status_observer_;
+      status_observer_ = NULL;
+    }
+    notification_count_--;
+    return true;
+  }
+  return false;
+}
+
+
+NotificationManagerWin::~NotificationManagerWin() {
+  ReleaseNotification();
+
+  // this is to clean up status_observer_ if it is created by the constructor
+  if (status_observer_) {
+    StatusIcon* status_icon = status_tray_->GetStatusIcon();
+    if (status_icon)
+      status_icon->RemoveObserver(status_observer_);
+
+    delete status_observer_;
+    status_observer_ = NULL;
+  }
+}
+
+bool NotificationManagerWin::AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+  const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) {
+
+  content::RenderViewHost* host = content::RenderViewHost::FromID(render_process_id, render_view_id);
+  if (host == NULL)
+    return false;
+
+  content::Shell* shell = content::Shell::FromRenderViewHost(host);
+
+  if (bitmaps == NULL) {
+    // called from public function, save the params
+    DesktopNotificationParams desktop_notification_params;
+    desktop_notification_params.params_ = params;
+    desktop_notification_params.render_process_id_ = render_process_id;
+    desktop_notification_params.render_view_id_ = render_view_id;
+
+    // download the icon image first
+    content::WebContents::ImageDownloadCallback imageDownloadCallback = base::Bind(&NotificationManager::ImageDownloadCallback);
+    int id = shell->web_contents()->DownloadImage(params.icon_url, true, 0, imageDownloadCallback);
+    desktop_notification_params_[id] = desktop_notification_params;
+
+    // wait for the image download callback
+    return true;
+  }
+
+  // if we reach here, it means the function is called from image download callback
+  render_process_id_ = render_process_id;
+  render_view_id_ = render_view_id;
+  notification_id_ = params.notification_id;
+
+  // set the default notification icon as the app icon
+  gfx::Image icon = shell->window()->app_icon();
+
+  // always check if status icon is exist or not
+  StatusIcon* status_icon = status_tray_->GetStatusIcon();
+
+  // status_icon_ is null, it means we need to create and adds it to the tray
+  if (status_icon == NULL) {
+    nw::Package* package = shell->GetPackage();
+    status_icon_ = status_tray_->CreateStatusIcon(StatusTray::NOTIFICATION_TRAY_ICON,
+      *(shell->window()->app_icon().ToImageSkia()), base::UTF8ToUTF16(package->GetName()));
+    status_icon = status_icon_;
+    status_observer_ = new TrayObserver(this);
+    status_icon->AddObserver(status_observer_);
+  }
+
+  // add the counter
+  notification_count_++;
+  // try to get the notification icon image given by image download callback
+  if (bitmaps->size())
+    icon = gfx::Image::CreateFrom1xBitmap(bitmaps->at(0));
+
+  //if body is empty string, the baloon won't shown
+  base::string16 body = params.body;
+  if (body.empty()) body = L" ";
+  
+  //show the baloon
+  bool result = status_icon->DisplayBalloon(icon.IsEmpty() ? gfx::ImageSkia() : *icon.ToImageSkia(), params.title, body);
+  if (!result) {
+    DesktopNotificationPostError(L"DisplayBalloon fail");
+    ReleaseNotification();
+  }
+
+  return result;
+}
+
+bool NotificationManagerWin::CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) {
+  //windows  can only have 1 notification, cannot delete existing notification
+  return true;
+}
+} // namespace nw

--- a/src/nw_notification_manager_win.h
+++ b/src/nw_notification_manager_win.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2014 Jefry Tedjokusumo <jtg_gg@yahoo.com.sg>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef CONTENT_NW_NOTIFICATION_MANAGER_WIN_H_
+#define CONTENT_NW_NOTIFICATION_MANAGER_WIN_H_
+
+#include "content/nw/src/nw_notification_manager.h"
+class StatusTrayWin;
+class StatusIcon;
+
+namespace nw {
+class NotificationManagerWin : public NotificationManager{
+  // The global presentation of system tray.
+  StatusTrayWin* status_tray_;
+
+  // StatusIcon pointer created by ME
+  StatusIcon* status_icon_;
+
+  // number of notification in the queue
+  int notification_count_;
+
+  // decrement the status_icon_count_, if the value is 0 remove the status_icon_ from the tray
+  bool ReleaseNotification();
+
+  // Click observer.
+  friend class TrayObserver;
+  TrayObserver* status_observer_;
+
+  // variable to store the latest notification data, windows can only show 1 notification
+  int render_process_id_, render_view_id_, notification_id_;
+
+  // dispatch the events from the latest notification
+  bool DesktopNotificationPostClick() {
+    return NotificationManager::DesktopNotificationPostClick(render_process_id_, render_view_id_, notification_id_);
+  }
+  bool DesktopNotificationPostClose(bool by_user) {
+    return NotificationManager::DesktopNotificationPostClose(render_process_id_, render_view_id_, notification_id_, by_user);
+  }
+  bool DesktopNotificationPostDisplay() {
+    return NotificationManager::DesktopNotificationPostDisplay(render_process_id_, render_view_id_, notification_id_);
+  }
+  bool DesktopNotificationPostError(const base::string16& message) {
+    return NotificationManager::DesktopNotificationPostError(render_process_id_, render_view_id_, notification_id_, message);
+  }
+
+  // internal function for AddDesktopNotification
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker, const std::vector<SkBitmap>* bitmaps) OVERRIDE;
+
+public:
+  explicit NotificationManagerWin();
+  virtual ~NotificationManagerWin();
+  virtual bool AddDesktopNotification(const content::ShowDesktopNotificationHostMsgParams& params,
+    const int render_process_id, const int render_view_id, const bool worker) OVERRIDE{
+    return AddDesktopNotification(params, render_process_id, render_view_id, worker, NULL);
+  }
+  virtual bool CancelDesktopNotification(int render_process_id, int render_view_id, int notification_id) OVERRIDE;
+};
+
+} // namespace nw
+
+#endif // CONTENT_NW_NOTIFICATION_MANAGER_WIN_H_

--- a/src/shell_content_browser_client.cc
+++ b/src/shell_content_browser_client.cc
@@ -57,6 +57,7 @@
 #include "content/nw/src/media/media_internals.h"
 #include "content/nw/src/nw_package.h"
 #include "content/nw/src/nw_shell.h"
+#include "content/nw/src/nw_notification_manager.h"
 #include "content/nw/src/nw_version.h"
 #include "content/nw/src/shell_browser_context.h"
 #include "content/nw/src/shell_browser_main_parts.h"
@@ -447,6 +448,40 @@ void ShellContentBrowserClient::GetAdditionalMappedFilesForChildProcess(
 QuotaPermissionContext*
 ShellContentBrowserClient::CreateQuotaPermissionContext() {
   return new ShellQuotaPermissionContext();
+}
+
+void ShellContentBrowserClient::ShowDesktopNotification(
+  const ShowDesktopNotificationHostMsgParams& params,
+  int render_process_id,
+  int render_view_id,
+  bool worker) {
+#if defined(ENABLE_NOTIFICATIONS)
+  nw::NotificationManager *notificationManager = nw::NotificationManager::getSingleton();
+  if (notificationManager == NULL) {
+    NOTIMPLEMENTED();
+    return;
+  }
+  notificationManager->AddDesktopNotification(params, render_process_id, render_view_id, worker);
+#else
+  NOTIMPLEMENTED();
+#endif
+
+}
+
+void ShellContentBrowserClient::CancelDesktopNotification(
+  int render_process_id,
+  int render_view_id,
+  int notification_id) {
+#if defined(ENABLE_NOTIFICATIONS)
+  nw::NotificationManager *notificationManager = nw::NotificationManager::getSingleton();
+  if (notificationManager == NULL) {
+    NOTIMPLEMENTED();
+    return;
+  }
+  notificationManager->CancelDesktopNotification(render_process_id, render_view_id, notification_id);
+#else
+  NOTIMPLEMENTED();
+#endif
 }
 
 }  // namespace content

--- a/src/shell_content_browser_client.h
+++ b/src/shell_content_browser_client.h
@@ -93,6 +93,18 @@ class ShellContentBrowserClient : public ContentBrowserClient {
 #endif
   virtual QuotaPermissionContext* CreateQuotaPermissionContext() OVERRIDE;
 
+  //Notification
+  virtual void ShowDesktopNotification(
+    const ShowDesktopNotificationHostMsgParams& params,
+    int render_process_id,
+    int render_view_id,
+    bool worker) OVERRIDE;
+    
+   virtual void CancelDesktopNotification(
+    int render_process_id,
+    int render_view_id,
+    int notification_id) OVERRIDE;
+
  private:
   ShellBrowserContext* ShellBrowserContextForBrowserContext(
       BrowserContext* content_browser_context);


### PR DESCRIPTION
Implement webkit dekstop notification (with image url and event dispatcher for click, close, display, error to javascript)
currently only implemented for Windows and MAC

![screen shot 2014-06-09 at 6 59 08 pm](https://cloud.githubusercontent.com/assets/4043527/3228376/32bc3106-f086-11e3-8ee4-90b984017dce.png)

![windowsnotification](https://cloud.githubusercontent.com/assets/4043527/3228382/3d268c54-f086-11e3-814a-8df58ac2468b.png)

the windows version will need some chrome source modification, I've made the pull request here:
https://github.com/rogerwang/chromium.src/pull/12 
