### PR TITLE
Fix nw0.8 DispatcherHost::OnCallObjectMethodSync()  warm output 

### DIFF
--- a/src/api/dispatcher_host.cc
+++ b/src/api/dispatcher_host.cc
@@ -186,12 +186,13 @@ void DispatcherHost::OnCallObjectMethodSync(
              << " arguments:" << arguments;
 
   Base* object = GetApiObject(object_id);
-  LOG(WARNING) << "Unknown object: " << object_id
+  if (object)
+    object->CallSync(method, arguments, result);
+  else
+    LOG(WARNING) << "Unknown object: " << object_id
              << " type:" << type
              << " method:" << method
              << " arguments:" << arguments;
-  if (object)
-    object->CallSync(method, arguments, result);
 }
 
 void DispatcherHost::OnCallStaticMethod(


### PR DESCRIPTION
Fix nw0.8 [DispatcherHost::OnCallObjectMethodSync()](https://github.com/rogerwang/node-webkit/blob/nw0.8/src/api/dispatcher_host.cc#L189) warm output 