### PR TITLE
[FlashFrame] change NativeWindow::FlashFrame input parameter to int, the javascript boolean parameter true redirected as -1, false as 0

### DIFF
--- a/src/api/window/window.cc
+++ b/src/api/window/window.cc
@@ -254,9 +254,9 @@ void Window::Call(const std::string& method,
         arguments.GetInteger(1, &y))
       shell_->window()->SetPosition(gfx::Point(x, y));
   } else if (method == "RequestAttention") {
-    bool flash;
-    if (arguments.GetBoolean(0, &flash))
-      shell_->window()->FlashFrame(flash);
+    int count;
+    if (arguments.GetInteger(0, &count))
+      shell_->window()->FlashFrame(count);
   } else if (method == "SetBadgeLabel") {
     std::string label;
     if (arguments.GetString(0, &label))

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -408,7 +408,10 @@ Window.prototype.setShowInTaskbar = function(flag) {
 }
 
 Window.prototype.requestAttention = function(flash) {
-  flash = Boolean(flash);
+  if (typeof flash == 'boolean') {
+    // boolean true is redirected as -1 value
+    flash = flash ? -1 : 0;
+  }
   CallObjectMethod(this, 'RequestAttention', [ flash ]);
 }
 

--- a/src/browser/native_window.h
+++ b/src/browser/native_window.h
@@ -99,7 +99,7 @@ class NativeWindow {
   virtual void SetPosition(const gfx::Point& position) = 0;
   virtual gfx::Point GetPosition() = 0;
   virtual void SetTitle(const std::string& title) = 0;
-  virtual void FlashFrame(bool flash) = 0;
+  virtual void FlashFrame(int count) = 0;
   virtual void SetBadgeLabel(const std::string& badge) = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;

--- a/src/browser/native_window_gtk.cc
+++ b/src/browser/native_window_gtk.cc
@@ -294,8 +294,8 @@ void NativeWindowGtk::SetTitle(const std::string& title) {
   gtk_window_set_title(GTK_WINDOW(window_), title.c_str());
 }
 
-void NativeWindowGtk::FlashFrame(bool flash) {
-  gtk_window_set_urgency_hint(window_, flash);
+void NativeWindowGtk::FlashFrame(int count) {
+  gtk_window_set_urgency_hint(window_, count);
 }
 
 void NativeWindowGtk::SetBadgeLabel(const std::string& badge) {

--- a/src/browser/native_window_gtk.h
+++ b/src/browser/native_window_gtk.h
@@ -59,7 +59,7 @@ class NativeWindowGtk : public NativeWindow {
   virtual void SetPosition(const gfx::Point& position) OVERRIDE;
   virtual gfx::Point GetPosition() OVERRIDE;
   virtual void SetTitle(const std::string& title) OVERRIDE;
-  virtual void FlashFrame(bool flash) OVERRIDE;
+  virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;

--- a/src/browser/native_window_mac.h
+++ b/src/browser/native_window_mac.h
@@ -63,7 +63,7 @@ class NativeWindowCocoa : public NativeWindow {
   virtual void SetPosition(const gfx::Point& position) OVERRIDE;
   virtual gfx::Point GetPosition() OVERRIDE;
   virtual void SetTitle(const std::string& title) OVERRIDE;
-  virtual void FlashFrame(bool flash) OVERRIDE;
+  virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;

--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -636,9 +636,9 @@ void NativeWindowCocoa::SetTitle(const std::string& title) {
   [window() setTitle:base::SysUTF8ToNSString(title)];
 }
 
-void NativeWindowCocoa::FlashFrame(bool flash) {
-  if (flash) {
-    attention_request_id_ = [NSApp requestUserAttention:NSInformationalRequest];
+void NativeWindowCocoa::FlashFrame(int count) {
+  if (count != 0) {
+    attention_request_id_ = count < 0 ? [NSApp requestUserAttention:NSInformationalRequest] : [NSApp requestUserAttention:NSCriticalRequest];
   } else {
     [NSApp cancelUserAttentionRequest:attention_request_id_];
     attention_request_id_ = 0;

--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -479,8 +479,19 @@ gfx::Point NativeWindowWin::GetPosition() {
   return window_->GetWindowBoundsInScreen().origin();
 }
 
-void NativeWindowWin::FlashFrame(bool flash) {
-  window_->FlashFrame(flash);
+void NativeWindowWin::FlashFrame(int count) {
+  FLASHWINFO fwi;
+  fwi.cbSize = sizeof(fwi);
+  fwi.hwnd = views::HWNDForWidget(window_);
+  if (count != 0) {
+    fwi.dwFlags = FLASHW_ALL;
+    fwi.uCount = count < 0 ? 4 : count;
+    fwi.dwTimeout = 0;
+  }
+  else {
+    fwi.dwFlags = FLASHW_STOP;
+  }
+  FlashWindowEx(&fwi);
 }
 
 HICON createBadgeIcon(const HWND hWnd, const TCHAR *value, const int sizeX, const int sizeY) {

--- a/src/browser/native_window_win.h
+++ b/src/browser/native_window_win.h
@@ -84,7 +84,7 @@ class NativeWindowWin : public NativeWindow,
   virtual void SetPosition(const gfx::Point& position) OVERRIDE;
   virtual gfx::Point GetPosition() OVERRIDE;
   virtual void SetTitle(const std::string& title) OVERRIDE;
-  virtual void FlashFrame(bool flash) OVERRIDE;
+  virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;


### PR DESCRIPTION
[FlashFrame] change NativeWindow::FlashFrame input parameter to int, the javascript boolean parameter true redirected as -1, false as 0

so on windows we can specify how many time to flash frame
and on OSX we can choose between NSInformationalRequest / NSCriticalRequest
