### PR TITLE
[ProgressBar] OSX, Win, Ubuntu implementation

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -104,6 +104,8 @@
         '<(DEPTH)/chrome/browser/ui/base_window.h',
         '<(DEPTH)/chrome/browser/ui/gtk/gtk_window_util.cc',
         '<(DEPTH)/chrome/browser/ui/gtk/gtk_window_util.h',
+        '<(DEPTH)/chrome/browser/ui/gtk/unity_service.cc',
+        '<(DEPTH)/chrome/browser/ui/gtk/unity_service.h',
         '<(DEPTH)/chrome/browser/ui/views/status_icons/status_icon_win.cc',
         '<(DEPTH)/chrome/browser/ui/views/status_icons/status_icon_win.h',
         '<(DEPTH)/chrome/browser/ui/views/status_icons/status_tray_win.cc',

--- a/src/api/window/window.cc
+++ b/src/api/window/window.cc
@@ -263,6 +263,10 @@ void Window::Call(const std::string& method,
     std::string label;
     if (arguments.GetString(0, &label))
       shell_->window()->SetBadgeLabel(label);
+  } else if (method == "SetProgressBar") {
+    double progress;
+    if (arguments.GetDouble(0, &progress))
+      shell_->window()->SetProgressBar(progress);
   } else if (method == "SetMenu") {
     int id;
     if (arguments.GetInteger(0, &id))

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -420,6 +420,12 @@ Window.prototype.setBadgeLabel = function(label) {
   CallObjectMethod(this, 'SetBadgeLabel', [ label ]);
 }
 
+Window.prototype.setProgressBar = function(progress) {
+  if (typeof progress != "number")
+    throw new String('progress must be a number');
+  CallObjectMethod(this, 'SetProgressBar', [ progress ]);
+}
+
 Window.prototype.setPosition = function(position) {
   if (position != 'center' && position != 'mouse')
     throw new String('Invalid postion');

--- a/src/browser/native_window.h
+++ b/src/browser/native_window.h
@@ -101,6 +101,7 @@ class NativeWindow {
   virtual void SetTitle(const std::string& title) = 0;
   virtual void FlashFrame(int count) = 0;
   virtual void SetBadgeLabel(const std::string& badge) = 0;
+  virtual void SetProgressBar(double progress) = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual void SetMenu(nwapi::Menu* menu) = 0;

--- a/src/browser/native_window_gtk.cc
+++ b/src/browser/native_window_gtk.cc
@@ -23,7 +23,9 @@
 #include <gdk/gdk.h>
 
 #include "base/values.h"
+#include "base/environment.h"
 #include "chrome/browser/ui/gtk/gtk_window_util.h"
+#include "chrome/browser/ui/gtk/unity_service.h"
 #include "extensions/common/draggable_region.h"
 #include "content/nw/src/api/menu/menu.h"
 #include "content/nw/src/common/shell_switches.h"
@@ -36,6 +38,15 @@
 #include "ui/gfx/gtk_util.h"
 #include "ui/gfx/rect.h"
 #include "ui/gfx/skia_utils_gtk.h"
+
+namespace ShellIntegrationLinux {
+std::string GetDesktopName(base::Environment* env) {
+  std::string name;
+  if (env->GetVar("NW_DESKTOP", &name) && !name.empty())
+    return name;
+  return "nw.desktop";
+}
+}
 
 namespace nw {
 
@@ -299,7 +310,15 @@ void NativeWindowGtk::FlashFrame(int count) {
 }
 
 void NativeWindowGtk::SetBadgeLabel(const std::string& badge) {
-  // TODO
+  if (unity::IsRunning()) {
+    unity::SetDownloadCount(atoi(badge.c_str()));
+  }
+}
+
+void NativeWindowGtk::SetProgressBar(double progress) {
+  if (unity::IsRunning()) {
+    unity::SetProgressFraction(progress);
+  }
 }
 
 void NativeWindowGtk::SetKiosk(bool kiosk) {

--- a/src/browser/native_window_gtk.h
+++ b/src/browser/native_window_gtk.h
@@ -61,6 +61,7 @@ class NativeWindowGtk : public NativeWindow {
   virtual void SetTitle(const std::string& title) OVERRIDE;
   virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
+  virtual void SetProgressBar(double progress) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;

--- a/src/browser/native_window_mac.h
+++ b/src/browser/native_window_mac.h
@@ -65,6 +65,7 @@ class NativeWindowCocoa : public NativeWindow {
   virtual void SetTitle(const std::string& title) OVERRIDE;
   virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
+  virtual void SetProgressBar(double progress) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;

--- a/src/browser/native_window_win.cc
+++ b/src/browser/native_window_win.cc
@@ -541,6 +541,37 @@ void NativeWindowWin::SetBadgeLabel(const std::string& badge) {
   DestroyIcon(icon);
 }
 
+void NativeWindowWin::SetProgressBar(double progress) {
+  base::win::ScopedComPtr<ITaskbarList3> taskbar;
+  HRESULT result = taskbar.CreateInstance(CLSID_TaskbarList, NULL,
+                                          CLSCTX_INPROC_SERVER);
+  
+  if (FAILED(result)) {
+    VLOG(1) << "Failed creating a TaskbarList3 object: " << result;
+    return;
+  }
+  
+  result = taskbar->HrInit();
+  if (FAILED(result)) {
+    LOG(ERROR) << "Failed initializing an ITaskbarList3 interface.";
+    return;
+  }
+  
+  HWND hWnd = views::HWNDForWidget(window_);
+  
+  TBPFLAG tbpFlag = TBPF_NOPROGRESS;
+  
+  if (progress > 1) {
+    tbpFlag = TBPF_INDETERMINATE;
+  }
+  else if (progress >= 0) {
+    tbpFlag = TBPF_NORMAL;
+    taskbar->SetProgressValue(hWnd, progress * 100, 100);
+  }
+  
+  taskbar->SetProgressState(hWnd, tbpFlag);
+}
+
 void NativeWindowWin::SetKiosk(bool kiosk) {
   SetFullscreen(kiosk);
 }

--- a/src/browser/native_window_win.h
+++ b/src/browser/native_window_win.h
@@ -87,6 +87,7 @@ class NativeWindowWin : public NativeWindow,
   virtual void FlashFrame(int count) OVERRIDE;
   virtual void SetKiosk(bool kiosk) OVERRIDE;
   virtual void SetBadgeLabel(const std::string& badge) OVERRIDE;
+  virtual void SetProgressBar(double progress) OVERRIDE;
   virtual bool IsKiosk() OVERRIDE;
   virtual void SetMenu(nwapi::Menu* menu) OVERRIDE;
   virtual void SetToolbarButtonEnabled(TOOLBAR_BUTTON button,


### PR DESCRIPTION
adding javascript function
Window.setProgressBar(double val)
valid values are 0 to 1 
val < 0 means remove the progress bar
val > 1 means indeterminate

Mac screenshot
![screen shot 2014-08-06 at 1 51 53 pm](https://cloud.githubusercontent.com/assets/4043527/3822859/f46023fa-1d2f-11e4-9994-57fcf45ecbfa.png)

Windows screenshot
![screen shot 2014-08-06 at 1 50 20 pm](https://cloud.githubusercontent.com/assets/4043527/3822860/f93a4464-1d2f-11e4-8f74-c8aa4176809e.png)

Linux screenshot (currently only works with Ubuntu)
if anyone know if these features are supported on Gnome / KDE, let me know
in Ubuntu you must make a .desktop file, then set the app env NW_DESKTOP to that .desktop file, or by default it will search for nw.desktop
![screen shot 2014-08-05 at 6 53 07 pm](https://cloud.githubusercontent.com/assets/4043527/3822861/febd2640-1d2f-11e4-9096-eb5a8451a916.png)
