### PR TITLE
Fix #2167 on Windows

### DIFF
--- a/src/renderer/shell_content_renderer_client.cc
+++ b/src/renderer/shell_content_renderer_client.cc
@@ -273,7 +273,7 @@ void ShellContentRendererClient::SetupNodeUtil(
         "if (!process.mainModule.filename || process.mainModule.filename === 'blank') {"
         "  var root = '" + root_path + "';"
 #if defined(OS_WIN)
-        "process.mainModule.filename = decodeURIComponent(window.location.pathname.substr(1));"
+        "process.mainModule.filename = decodeURIComponent(window.location.pathname === 'blank' ? 'blank': window.location.pathname.substr(1));"
 #else
         "process.mainModule.filename = decodeURIComponent(window.location.pathname);"
 #endif
@@ -282,7 +282,7 @@ void ShellContentRendererClient::SetupNodeUtil(
         "process.mainModule.paths = global.require('module')._nodeModulePaths(process.cwd());"
         "process.mainModule.loaded = true;"
         "}").c_str()),
-                                                       v8::String::NewFromUtf8(isolate, "process_main"));
+  v8::String::NewFromUtf8(isolate, "process_main"));
   CHECK(*script);
   script->Run();
 }


### PR DESCRIPTION
The origin fix checks if the filename is empty or `"blank"`. If so, on Windows, the filename is stripped from second letter of `location.pathname`. However in case of "blank" location, it results in setting `process.mainModule.filename` to `"lank"` instead of `"blank"`. This will cause the check fails in the next call.
