### PR TITLE
[Notification] OSX, disable the default sound

### DIFF
--- a/src/nw_notification_manager_mac.mm
+++ b/src/nw_notification_manager_mac.mm
@@ -132,7 +132,6 @@ bool NotificationManagerMac::AddDesktopNotification(const content::ShowDesktopNo
     @"notification_id" :[NSNumber numberWithInt : params.notification_id],
   };
 
-  [notification setSoundName : @"NSUserNotificationDefaultSoundName"];
 
   [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[NWUserNotificationCenterDelegate defaultNWUserNotificationCenterDelegate]];
 


### PR DESCRIPTION
as requested by many user https://github.com/rogerwang/node-webkit/issues/27#issuecomment-53625018
I agree with them, the notification sound can be played using audio api
