### PR TITLE
Initialize Package earlier to evaluate commandline args earlier (fixes #1743)

### DIFF
--- a/src/shell_browser_main_parts.cc
+++ b/src/shell_browser_main_parts.cc
@@ -160,6 +160,7 @@ int ShellBrowserMainParts::PreCreateThreads() {
   gfx::Screen::SetScreenInstance(gfx::SCREEN_TYPE_NATIVE,
                                  views::CreateDesktopScreen());
 #endif
+  package_.reset(new nw::Package());
   return 0;
 }
 
@@ -180,7 +181,6 @@ void ShellBrowserMainParts::ToolkitInitialized() {
 }
 
 void ShellBrowserMainParts::Init() {
-  package_.reset(new nw::Package());
   CommandLine& command_line = *CommandLine::ForCurrentProcess();
 
   browser_context_.reset(new ShellBrowserContext(false, package()));


### PR DESCRIPTION
On package initialization, flags from "chromium-args" are added to the Chromium commandline.
Previously, the Package object was initialized in the "PreMainMessageLoopRun" step.
As the GPU flags are already evaluated in the "BrowserThreadsStarted" step (which is before that), this was too late for flags like "--ignore-gpu-blacklist".
