### PR TITLE
Avoid failure on debug check of replacements

### DIFF
--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -86,7 +86,7 @@ if (require('os').platform() === 'darwin'){
         key: "h"
     }));
     appleMenu.append(new exports.MenuItem({
-        label: nw.getNSStringFWithFixup("IDS_HIDE_OTHERS_MAC", app_name),
+        label: nw.getNSStringWithFixup("IDS_HIDE_OTHERS_MAC"),
         selector: "hideOtherApplications:",
         key: "h",
         modifiers: "cmd-alt"


### PR DESCRIPTION
"Hide Others" menu item doesn't accept any replacements. Providing replacements will fail the debug check and block the execution.
