### PR TITLE
Fix #2469: Changed Window.open to ignore slashes in parameters.

### DIFF
--- a/src/api/window/window.js
+++ b/src/api/window/window.js
@@ -48,7 +48,7 @@ exports.Window = {
     // Conver relative url to full url.
     var protocol = url.match(/^[a-z]+:\/\//i);
     if (protocol == null || protocol.length == 0) {
-      var href = window.location.href;
+      var href = window.location.href.split(/\?|#/)[0];
       url = href.substring(0, href.lastIndexOf('/') + 1) + url;
     }
 


### PR DESCRIPTION
Changed the URL handling code which converts a relative path to a full path to ignore everything behind "#" as this is  an anchor and should not be treated as a path as well as parameters starting with "?"
