### PR TITLE
Executable within OSX is in a hidden directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ $ /path/to/nw .  (suppose the current directory contains 'package.json')
 
 Note: on Windows, you can drag the folder containing `package.json` to `nw.exe` to open it.
 
+Note: on OSX, the executable binary is in a hidden directory within the .app file. To run node-webkit on OSX, type:
+```bash
+$ /path/to/node-webkit.app/Contents/MacOS/node-webkit .  (suppose the current directory contains 'package.json')
+```
 ## Documents
 
 For more information on how to write/package/run apps, see:


### PR DESCRIPTION
Helps resolve https://github.com/rogerwang/node-webkit/issues/2530
