### PR TITLE
Don't activate app unconditionally on window "Show".

### DIFF
--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -478,7 +478,7 @@ void NativeWindowCocoa::Focus(bool focus) {
 
 void NativeWindowCocoa::Show() {
   NSApplication *myApp = [NSApplication sharedApplication];
-  [myApp activateIgnoringOtherApps:YES];
+  [myApp activateIgnoringOtherApps:NO];
   content::RenderWidgetHostView* rwhv =
       shell_->web_contents()->GetRenderWidgetHostView();
 


### PR DESCRIPTION
Fixes issue where new window is opened using `gui.Window.open(...)` while app is in background.
Should also fix #1032.
