### PR TITLE
[OSX] Fix alticon property of Tray not being updated properly

### DIFF
--- a/src/api/tray/tray.js
+++ b/src/api/tray/tray.js
@@ -100,7 +100,7 @@ Tray.prototype.__defineSetter__('icon', function(val) {
 Tray.prototype.__defineSetter__('alticon', function(val) {
   v8_util.getHiddenValue(this, 'option').shadowAlticon = String(val);
   var real_path = val == '' ? '' : nw.getAbsolutePath(val);
-  this.handleSetter('alticon', 'SetAlticon', String, real_path);
+  this.handleSetter('alticon', 'SetAltIcon', String, real_path);
 });
 
 Tray.prototype.__defineGetter__('tooltip', function() {


### PR DESCRIPTION
- Fix the setter of the `alticon` property (typo in method name).

Fix rogerwang/node-webkit#703
