### PR TITLE
[OSX] Fix Window.focus() not taking focus

### DIFF
--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -481,6 +481,8 @@ void NativeWindowCocoa::Move(const gfx::Rect& pos) {
 }
 
 void NativeWindowCocoa::Focus(bool focus) {
+  NSApplication *myApp = [NSApplication sharedApplication];
+  [myApp activateIgnoringOtherApps:YES];
   if (focus && [window() isVisible])
     [window() makeKeyAndOrderFront:nil];
   else


### PR DESCRIPTION
Add back `NSApplication activateIgnoringOtherApps:YES` only inside `Window.focus()`

FIX rogerwang/node-webkit#2724 and rogerwang/node-webkit#2735
