### PR TITLE
Add version check for libnotify

### DIFF
--- a/src/nw_notification_manager_linux.cc
+++ b/src/nw_notification_manager_linux.cc
@@ -113,8 +113,18 @@ bool NotificationManagerLinux::AddDesktopNotification(const content::ShowDesktop
   NotifyNotification * notif;
   NotificationMap::iterator i = getNotification(notification_id);
   if (i==mNotificationIDmap.end()) {
+#ifdef NOTIFY_CHECK_VERSION
+#if NOTIFY_CHECK_VERSION(0,7,0)
     notif = notify_notification_new (
       base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL);
+#else
+    notif = notify_notification_new (
+      base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL, NULL);
+#endif
+#else
+    notif = notify_notification_new (
+      base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL, NULL);
+#endif
     NotificationData data;
     data.mNotification = notif;
     data.mRenderProcessId = render_process_id;


### PR DESCRIPTION
This allows node-webkit to be built on CentOS (see issues #684, #1966).
