### PR TITLE
Update test case accounting for multiple workspaces

### DIFF
--- a/tests/manual_tests/custom_tray_menu/index.html
+++ b/tests/manual_tests/custom_tray_menu/index.html
@@ -14,7 +14,7 @@
     var customTrayMenu = gui.Window.open('custom-tray-menu.html', {
       width: 100, height: 120,
       frame: false, toolbar: false, 
-      show: false
+      show: false, 'visible-on-all-workspaces': true
     });
     var iconWidth = 13;
     var translate = require('os').platform() == 'darwin' ?


### PR DESCRIPTION
Set `'visible-on-all-workspaces'` to `true` so the custom tray menu is displayed on all workspaces.

As @FWeinb suggested in https://github.com/rogerwang/node-webkit/pull/2799#issuecomment-67094763 