### PR TITLE
Fix tray title/tooltip issues on Mac OS X

### DIFF
--- a/src/api/tray/tray.cc
+++ b/src/api/tray/tray.cc
@@ -51,7 +51,7 @@ Tray::Tray(int id,
 
   std::string tooltip;
   if (option.GetString("tooltip", &tooltip))
-    SetTitle(tooltip);
+    SetTooltip(tooltip);
 
   int menu_id;
   if (option.GetInteger("menu", &menu_id))

--- a/src/api/tray/tray.h
+++ b/src/api/tray/tray.h
@@ -64,7 +64,7 @@ class Tray : public Base {
   void Destroy();
   void SetTitle(const std::string& title);
   void SetIcon(const std::string& icon_path);
-  void SetTooltip(const std::string& title);
+  void SetTooltip(const std::string& tooltip);
   void SetMenu(Menu* menu);
   void Remove();
   // Alternate icons only work with Macs

--- a/src/api/tray/tray_mac.mm
+++ b/src/api/tray/tray_mac.mm
@@ -75,6 +75,11 @@ void Tray::Destroy() {
 }
 
 void Tray::SetTitle(const std::string& title) {
+  // note: this is kind of mad but the first time we set the title property 
+  // we have to call setTitle twice or it won't get the right dimensions
+  if ([status_item_ title] != nil) {
+    [status_item_ setTitle:[NSString stringWithUTF8String:title.c_str()]];
+  }
   [status_item_ setTitle:[NSString stringWithUTF8String:title.c_str()]];
 }
 


### PR DESCRIPTION
- Fix `tooltip` option in `Tray` creation being used for `title`.
- Fix `title` option in in `Tray` resulting in the title being truncated.
- Fix setting `title` field in `Tray` resulting in the title being truncated.

NOTE: the fist time we set the title property we have to call `setTitle` twice
or it won't get the right dimensions.

FIX rogerwang/node-webkit#2796
