### PR TITLE
Fixed title for devtools

### DIFF
--- a/src/shell_devtools_frontend.h
+++ b/src/shell_devtools_frontend.h
@@ -51,6 +51,8 @@ class ShellDevToolsFrontend : public WebContentsObserver,
   virtual void InspectedContentsClosing() OVERRIDE;
   virtual void ReplacedWithAnotherClient() OVERRIDE {}
 
+  virtual void InspectedURLChanged(const std::string& url);
+
   Shell* frontend_shell_;
   scoped_refptr<DevToolsAgentHost> agent_host_;
   scoped_ptr<DevToolsFrontendHost> frontend_host_;


### PR DESCRIPTION
When frontend host is registered for devtools, "inspectedURLChanged" message is sent to frontend host when devtools is loaded. This fix handles the message and resets the title to show current inspected page.