### PR TITLE
updated release notes links to new group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/tmp-nw
 .pydevproject
 tags
 Thumbs.db
+/nbproject/

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ It was created in the Intel Open Source Technology Center.
 * Available on Linux, Mac OS X and Windows
 
 ## Downloads
-* **v0.11.5:** (Dec 28, 2014, based off of Node v0.11.13, Chromium 38.0.2125.104): [release notes](https://groups.google.com/d/msg/node-webkit/ZjxFVdgWxKE/UevinvOIqzEJ)
+* **v0.11.5:** (Dec 28, 2014, based off of Node v0.11.13, Chromium 38.0.2125.104): [release notes](https://groups.google.com/d/msg/nwjs-general/ZjxFVdgWxKE/UevinvOIqzEJ)
 
  * Linux: [32bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-linux-ia32.tar.gz) / [64bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-linux-x64.tar.gz)
  * Windows: [32bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-win-ia32.zip) / [64bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-win-x64.zip)
  * Mac 10.7+: [32bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-osx-ia32.zip) / [64bit](http://dl.node-webkit.org/v0.11.5/node-webkit-v0.11.5-osx-x64.zip)
 
-* **0.8.6:** (Apr 18, 2014, based off of Node v0.10.22, Chrome 30.0.1599.66) **If your native Node module works only with Node v0.10, then you should use node-webkit v0.8.x, which is also a maintained branch. [More info](https://groups.google.com/d/msg/node-webkit/2OJ1cEMPLlA/09BvpTagSA0J)**  
-[release notes](https://groups.google.com/d/msg/node-webkit/CLPkgfV-i7s/hwkkQuJ1kngJ)
+* **0.8.6:** (Apr 18, 2014, based off of Node v0.10.22, Chrome 30.0.1599.66) **If your native Node module works only with Node v0.10, then you should use node-webkit v0.8.x, which is also a maintained branch. [More info](https://groups.google.com/d/msg/nwjs-general/2OJ1cEMPLlA/09BvpTagSA0J)**  
+[release notes](https://groups.google.com/d/msg/nwjs-general/CLPkgfV-i7s/hwkkQuJ1kngJ)
 
  * Linux: [32bit](http://dl.node-webkit.org/v0.8.6/node-webkit-v0.8.6-linux-ia32.tar.gz) / [64bit](http://dl.node-webkit.org/v0.8.6/node-webkit-v0.8.6-linux-x64.tar.gz)
  * Windows: [win32](http://dl.node-webkit.org/v0.8.6/node-webkit-v0.8.6-win-ia32.zip)


### PR DESCRIPTION
The links to release notes for the downloads section were going to the old group, which does not exist. This showed a 404 error.