### PR TITLE
Fix random http cache crash on Windows

### DIFF
--- a/src/net/shell_url_request_context_getter.cc
+++ b/src/net/shell_url_request_context_getter.cc
@@ -241,9 +241,11 @@ net::URLRequestContext* ShellURLRequestContextGetter::GetURLRequestContext() {
     net::HttpCache::DefaultBackend* main_backend =
         new net::HttpCache::DefaultBackend(
             net::DISK_CACHE,
-            net::CACHE_BACKEND_SIMPLE,
+            // switched to CACHE_BACKEND_DEFAULT to prevent random cache crashes
+            // on Windows
+            net::CACHE_BACKEND_DEFAULT,
             cache_path,
-            10 * 1024 * 1024,  // 10M
+            0, // system determin the cache size
             BrowserThread::GetMessageLoopProxyForThread(
                 BrowserThread::CACHE));
 


### PR DESCRIPTION
HTTP cache randomly crashes on exiting NW on Windows. Switching the cache backend from `CACHE_BACKEND_SIMPLE` to `CACHE_BACKEND_DEFAULT` fixes this issue.