### PR TITLE
[Screen Selection] OSX and Win implementation

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -81,6 +81,8 @@
         '<(DEPTH)/ui/resources/ui_resources.gyp:ui_resources',
         '<(DEPTH)/url/url.gyp:url_lib',
         '<(DEPTH)/v8/tools/gyp/v8.gyp:v8',
+        '<(DEPTH)/third_party/libyuv/libyuv.gyp:libyuv',
+        '<(DEPTH)/third_party/webrtc/modules/modules.gyp:desktop_capture',
         '<(DEPTH)/third_party/zlib/zlib.gyp:minizip',
         '<(DEPTH)/third_party/WebKit/public/blink.gyp:blink',
         '<(DEPTH)/extensions/browser/api/api_registration.gyp:extensions_api_registration',
@@ -203,6 +205,13 @@
         'src/api/dispatcher_host.h',
         'src/api/event/event.h',
         'src/api/event/event.cc',
+        'src/api/screen/desktop_capture_api.h',
+        'src/api/screen/desktop_capture_api.cc',
+        '<(DEPTH)/chrome/browser/media/desktop_media_list.h',
+        '<(DEPTH)/chrome/browser/media/desktop_media_list_observer.h',
+        '<(DEPTH)/chrome/browser/media/desktop_media_picker.h',
+        '<(DEPTH)/chrome/browser/media/native_desktop_media_list.h',
+        '<(DEPTH)/chrome/browser/media/native_desktop_media_list.cc',
         'src/api/screen/screen.h',
         'src/api/screen/screen.cc',
         'src/api/window_bindings.cc',
@@ -471,6 +480,8 @@
         }],
         ['use_aura==1', {
           'sources': [
+            '<(DEPTH)/chrome/browser/ui/views/desktop_media_picker_views.cc',
+            '<(DEPTH)/chrome/browser/ui/views/desktop_media_picker_views.h',
             '<(DEPTH)/chrome/browser/ui/views/web_contents_modal_dialog_manager_views.cc',
             'src/browser/login_view.cc',
             'src/browser/login_view.h',
@@ -536,11 +547,20 @@
           ],
           'sources': [
             #'<(DEPTH)/chrome/browser/ui/cocoa/web_contents_modal_dialog_manager_cocoa.mm',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_bridge.h',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_bridge.mm',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_cocoa.h',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_cocoa.mm',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_controller.h',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_controller.mm',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_item.h',
+            '<(DEPTH)/chrome/browser/ui/cocoa/media_picker/desktop_media_picker_item.mm',
             'src/browser/shell_web_contents_modal_dialog_manager.cc',
           ],
           'dependencies': [
             '<(DEPTH)/breakpad/breakpad.gyp:breakpad',
             '<(DEPTH)/components/components.gyp:crash_component',
+            '<(DEPTH)/third_party/google_toolbox_for_mac/google_toolbox_for_mac.gyp:google_toolbox_for_mac',
           ],
           'link_settings': {
             'libraries': [
@@ -747,6 +767,7 @@
           'action_name': 'repack_nw_pack',
           'variables': {
             'pak_inputs': [
+              '<(SHARED_INTERMEDIATE_DIR)/chrome/generated_resources_en-US.pak',
               '<(SHARED_INTERMEDIATE_DIR)/content/content_resources.pak',
               '<(SHARED_INTERMEDIATE_DIR)/content/nw_resources.pak',
               '<(SHARED_INTERMEDIATE_DIR)/content/nw_components.pak',
@@ -1195,6 +1216,13 @@
             'src/shell_content_main.h',
           ],
           'xcode_settings': { 'OTHER_LDFLAGS': [ '-Wl,-force_load,libnode.a' ], },
+          'link_settings': {
+            'xcode_settings': {
+              'OTHER_LDFLAGS': [
+                '-framework Quartz',
+              ],
+            },
+          },
           'copies': [
             {
               # Copy FFmpeg binaries for audio/video support.

--- a/src/api/screen/desktop_capture_api.cc
+++ b/src/api/screen/desktop_capture_api.cc
@@ -1,0 +1,221 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/nw/src/api/screen/desktop_capture_api.h"
+
+#include "base/command_line.h"
+#include "base/compiler_specific.h"
+#include "base/strings/utf_string_conversions.h"
+#include "chrome/browser/media/native_desktop_media_list.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/web_contents.h"
+#include "net/base/net_util.h"
+#include "third_party/webrtc/modules/desktop_capture/desktop_capture_options.h"
+#include "third_party/webrtc/modules/desktop_capture/screen_capturer.h"
+#include "third_party/webrtc/modules/desktop_capture/window_capturer.h"
+
+namespace nwapi {
+
+namespace {
+
+const char kEmptySourcesListError[] =
+    "At least one source type must be specified.";
+
+DesktopCaptureChooseDesktopMediaFunction::PickerFactory* g_picker_factory =
+    NULL;
+
+}  // namespace
+
+// static
+void DesktopCaptureChooseDesktopMediaFunction::SetPickerFactoryForTests(
+    PickerFactory* factory) {
+  g_picker_factory = factory;
+}
+
+DesktopCaptureChooseDesktopMediaFunction::
+    DesktopCaptureChooseDesktopMediaFunction() {
+}
+
+DesktopCaptureChooseDesktopMediaFunction::
+    ~DesktopCaptureChooseDesktopMediaFunction() {
+  // RenderViewHost may be already destroyed.
+  if (render_view_host()) {
+    DesktopCaptureRequestsRegistry::GetInstance()->RemoveRequest(
+        render_view_host()->GetProcess()->GetID(), request_id_);
+  }
+}
+
+void DesktopCaptureChooseDesktopMediaFunction::Cancel() {
+  // Keep reference to |this| to ensure the object doesn't get destroyed before
+  // we return.
+  scoped_refptr<DesktopCaptureChooseDesktopMediaFunction> self(this);
+  if (picker_) {
+    picker_.reset();
+    SetResult(new base::StringValue(std::string()));
+    SendResponse(true);
+  }
+}
+
+bool DesktopCaptureChooseDesktopMediaFunction::RunSync() {
+
+  DesktopCaptureRequestsRegistry::GetInstance()->AddRequest(
+      render_view_host()->GetProcess()->GetID(), request_id_, this);
+
+  // |web_contents| is the WebContents for which the stream is created, and will
+  // also be used to determine where to show the picker's UI.
+  content::WebContents* web_contents = content::WebContents::FromRenderViewHost(render_view_host());
+  DCHECK(web_contents);
+  base::string16 target_name;
+
+  // Register to be notified when the tab is closed.
+  Observe(web_contents);
+
+  bool show_screens = false;
+  bool show_windows = false;
+  
+  const base::ListValue* capture_param = NULL;
+  if(args_->GetList(1,&capture_param)) {
+    for(base::ListValue::const_iterator i = capture_param->begin(); i != capture_param->end(); i++) {
+      const base::Value* val = static_cast<const base::Value*>(*i);
+      std::string str;
+      if(val->GetAsString(&str)) {
+        if(!str.compare("window")) {
+          show_windows = true;
+          continue;
+        }
+        
+        if(!str.compare("screen")) {
+          show_screens = true;
+          continue;
+        }
+      }
+    }
+  }
+
+  if (!show_screens && !show_windows) {
+    error_ = kEmptySourcesListError;
+    return false;
+  }
+
+  const gfx::NativeWindow parent_window =
+      web_contents->GetTopLevelNativeWindow();
+  scoped_ptr<DesktopMediaList> media_list;
+  if (g_picker_factory) {
+    media_list = g_picker_factory->CreateModel(
+        show_screens, show_windows);
+    picker_ = g_picker_factory->CreatePicker();
+  } else {
+    {
+      webrtc::DesktopCaptureOptions options =
+          webrtc::DesktopCaptureOptions::CreateDefault();
+      options.set_disable_effects(false);
+      scoped_ptr<webrtc::ScreenCapturer> screen_capturer(
+          show_screens ? webrtc::ScreenCapturer::Create(options) : NULL);
+      scoped_ptr<webrtc::WindowCapturer> window_capturer(
+          show_windows ? webrtc::WindowCapturer::Create(options) : NULL);
+
+      media_list.reset(new NativeDesktopMediaList(
+          screen_capturer.Pass(), window_capturer.Pass()));
+    }
+
+    // DesktopMediaPicker is implemented only for Windows, OSX and
+    // Aura Linux builds.
+#if defined(TOOLKIT_VIEWS) || defined(OS_MACOSX)
+    picker_ = DesktopMediaPicker::Create();
+#else
+    error_ = "Desktop Capture API is not yet implemented for this platform.";
+    return false;
+#endif
+  }
+  DesktopMediaPicker::DoneCallback callback = base::Bind(
+      &DesktopCaptureChooseDesktopMediaFunction::OnPickerDialogResults, this);
+
+  picker_->Show(web_contents,
+                parent_window,
+                parent_window,
+                target_name,
+                target_name,
+                media_list.Pass(),
+                callback);
+  return true;
+}
+
+void DesktopCaptureChooseDesktopMediaFunction::WebContentsDestroyed() {
+  Cancel();
+}
+
+void DesktopCaptureChooseDesktopMediaFunction::OnPickerDialogResults(
+    content::DesktopMediaID source) {
+  std::string result;
+  if (source.type != content::DesktopMediaID::TYPE_NONE &&
+      web_contents()) {
+    result = source.ToString();
+  }
+
+  SetResult(new base::StringValue(result));
+  SendResponse(true);
+}
+
+DesktopCaptureRequestsRegistry::RequestId::RequestId(int process_id,
+                                                     int request_id)
+    : process_id(process_id),
+      request_id(request_id) {
+}
+
+bool DesktopCaptureRequestsRegistry::RequestId::operator<(
+    const RequestId& other) const {
+  if (process_id != other.process_id) {
+    return process_id < other.process_id;
+  } else {
+    return request_id < other.request_id;
+  }
+}
+
+DesktopCaptureCancelChooseDesktopMediaFunction::
+    DesktopCaptureCancelChooseDesktopMediaFunction() {}
+
+DesktopCaptureCancelChooseDesktopMediaFunction::
+    ~DesktopCaptureCancelChooseDesktopMediaFunction() {}
+
+bool DesktopCaptureCancelChooseDesktopMediaFunction::RunSync() {
+  int request_id;
+  EXTENSION_FUNCTION_VALIDATE(args_->GetInteger(0, &request_id));
+
+  DesktopCaptureRequestsRegistry::GetInstance()->CancelRequest(
+      render_view_host()->GetProcess()->GetID(), request_id);
+  return true;
+}
+
+DesktopCaptureRequestsRegistry::DesktopCaptureRequestsRegistry() {}
+DesktopCaptureRequestsRegistry::~DesktopCaptureRequestsRegistry() {}
+
+// static
+DesktopCaptureRequestsRegistry* DesktopCaptureRequestsRegistry::GetInstance() {
+  return Singleton<DesktopCaptureRequestsRegistry>::get();
+}
+
+void DesktopCaptureRequestsRegistry::AddRequest(
+    int process_id,
+    int request_id,
+    DesktopCaptureChooseDesktopMediaFunction* handler) {
+  requests_.insert(
+      RequestsMap::value_type(RequestId(process_id, request_id), handler));
+}
+
+void DesktopCaptureRequestsRegistry::RemoveRequest(int process_id,
+                                                   int request_id) {
+  requests_.erase(RequestId(process_id, request_id));
+}
+
+void DesktopCaptureRequestsRegistry::CancelRequest(int process_id,
+                                                   int request_id) {
+  RequestsMap::iterator it = requests_.find(RequestId(process_id, request_id));
+  if (it != requests_.end())
+    it->second->Cancel();
+}
+
+
+}  // namespace extensions

--- a/src/api/screen/desktop_capture_api.h
+++ b/src/api/screen/desktop_capture_api.h
@@ -1,0 +1,115 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef NWAPI_DESKTOP_CAPTURE_DESKTOP_CAPTURE_API_H_
+#define NWAPI_DESKTOP_CAPTURE_DESKTOP_CAPTURE_API_H_
+
+#include <map>
+
+#include "base/memory/singleton.h"
+#include "chrome/browser/media/desktop_media_list.h"
+#include "chrome/browser/media/desktop_media_picker.h"
+#include "chrome/browser/media/native_desktop_media_list.h"
+#include "extensions/browser/extension_function.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "url/gurl.h"
+
+namespace nwapi {
+
+class DesktopCaptureChooseDesktopMediaFunction
+    : public SyncExtensionFunction,
+      public content::WebContentsObserver {
+ public:
+
+  // Factory creating DesktopMediaList and DesktopMediaPicker instances.
+  // Used for tests to supply fake picker.
+  class PickerFactory {
+   public:
+    virtual scoped_ptr<DesktopMediaList> CreateModel(bool show_screens,
+                                                     bool show_windows) = 0;
+    virtual scoped_ptr<DesktopMediaPicker> CreatePicker() = 0;
+   protected:
+    virtual ~PickerFactory() {}
+  };
+
+  // Used to set PickerFactory used to create mock DesktopMediaPicker instances
+  // for tests. Calling tests keep ownership of the factory. Can be called with
+  // |factory| set to NULL at the end of the test.
+  static void SetPickerFactoryForTests(PickerFactory* factory);
+
+  DesktopCaptureChooseDesktopMediaFunction();
+
+  void Cancel();
+
+  // ExtensionFunction overrides.
+  bool RunSync() override;
+
+ private:
+  ~DesktopCaptureChooseDesktopMediaFunction() override;
+
+  // content::WebContentsObserver overrides.
+  void WebContentsDestroyed() override;
+
+  void OnPickerDialogResults(content::DesktopMediaID source);
+
+  int request_id_;
+
+  // URL of page that desktop capture was requested for.
+  GURL origin_;
+
+  scoped_ptr<DesktopMediaPicker> picker_;
+};
+
+// this api is not exposed in nwjs yet
+class DesktopCaptureCancelChooseDesktopMediaFunction
+    : public SyncExtensionFunction {
+ public:
+  DesktopCaptureCancelChooseDesktopMediaFunction();
+
+ private:
+  ~DesktopCaptureCancelChooseDesktopMediaFunction() override;
+
+  // ExtensionFunction overrides.
+  bool RunSync() override;
+};
+
+// this class is only needed if we want the ability to cancel "choose desktop media"
+// currently not used
+class DesktopCaptureRequestsRegistry {
+ public:
+  DesktopCaptureRequestsRegistry();
+  ~DesktopCaptureRequestsRegistry();
+
+  static DesktopCaptureRequestsRegistry* GetInstance();
+
+  void AddRequest(int process_id,
+                  int request_id,
+                  DesktopCaptureChooseDesktopMediaFunction* handler);
+  void RemoveRequest(int process_id, int request_id);
+  void CancelRequest(int process_id, int request_id);
+
+ private:
+  friend struct DefaultSingletonTraits<DesktopCaptureRequestsRegistry>;
+
+  struct RequestId {
+    RequestId(int process_id, int request_id);
+
+    // Need to use RequestId as a key in std::map<>.
+    bool operator<(const RequestId& other) const;
+
+    int process_id;
+    int request_id;
+  };
+
+  typedef std::map<RequestId,
+                   DesktopCaptureChooseDesktopMediaFunction*> RequestsMap;
+
+  RequestsMap requests_;
+
+  DISALLOW_COPY_AND_ASSIGN(DesktopCaptureRequestsRegistry);
+};
+
+}  // namespace extensions
+
+#endif  // NWAPI_DESKTOP_CAPTURE_DESKTOP_CAPTURE_API_H_

--- a/src/api/screen/screen.js
+++ b/src/api/screen/screen.js
@@ -28,7 +28,7 @@ require('util').inherits(Screen, exports.Base);
 
 // Override the addListener method.
 Screen.prototype.on = Screen.prototype.addListener = function(ev, callback) {
-  if ( ev != "displayBoundsChanged" && ev != "displayAdded" && ev != "displayRemoved" )
+  if ( ev != "displayBoundsChanged" && ev != "displayAdded" && ev != "displayRemoved" && ev != "chooseDesktopMedia")
     throw new String('only following event can be listened: displayBoundsChanged, displayAdded, displayRemoved');
   
   var onRemoveListener = function (type, listener) {
@@ -42,7 +42,7 @@ Screen.prototype.on = Screen.prototype.addListener = function(ev, callback) {
   };
 
   if(this._numListener == 0) {
-    if (nw.callStaticMethodSync('Screen', 'AddScreenChangeCallback', [ this.id ]) == false ) {
+    if (nw.callStaticMethodSync('Screen', 'AddScreenChangeCallback', [ this.id ])[0] == false ) {
       throw new String('nw.callStaticMethodSync(Screen, AddScreenChangeCallback) fails');
       return;
     }
@@ -56,7 +56,8 @@ Screen.prototype.on = Screen.prototype.addListener = function(ev, callback) {
 
 // Route events.
 Screen.prototype.handleEvent = function(ev) {
-  arguments[1] = JSON.parse(arguments[1]);
+  if (ev != "chooseDesktopMedia")
+    arguments[1] = JSON.parse(arguments[1]);
   // Call parent.
   this.emit.apply(this, arguments);
 }
@@ -65,6 +66,13 @@ Screen.prototype.__defineGetter__('screens', function() {
   return JSON.parse(nw.callStaticMethodSync('Screen', 'GetScreens', [ ]));
 });
 
+Screen.prototype.chooseDesktopMedia = function(array, callback) {
+  if(nw.callStaticMethodSync('Screen', 'ChooseDesktopMedia', [ this.id, array ])[0]) {
+    this.once('chooseDesktopMedia', callback);
+    return true;
+  }
+  return false;
+}
 
 // ======== Screen functions End ========
 

--- a/src/nw_shell.h
+++ b/src/nw_shell.h
@@ -31,6 +31,7 @@
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 #if defined(OS_WIN) || defined(OS_LINUX)
+#include "components/web_modal/popup_manager.h"
 #include "components/web_modal/web_contents_modal_dialog_manager_delegate.h"
 #endif
 #include "ipc/ipc_channel.h"
@@ -228,6 +229,10 @@ class Shell : public WebContentsDelegate,
   scoped_ptr<WebContents> web_contents_;
   scoped_ptr<nw::NativeWindow> window_;
   scoped_ptr<extensions::ExtensionFunctionDispatcher> extension_function_dispatcher_;
+
+#if defined(OS_WIN) || defined(OS_LINUX)
+  scoped_ptr<web_modal::PopupManager> popup_manager_;
+#endif
 
   // Notification manager.
   NotificationRegistrar registrar_;


### PR DESCRIPTION
Chrome Screen Selection does not work ubuntu linux
hence I am not yet supporting it on linux

how to use it:
var gui = require('nw.gui');
gui.Screen.Init();
gui.Screen.chooseDesktopMedia(["window","screen"], 
 function(streamId) {
  var vid_cons = {mandatory: {chromeMediaSource: 'desktop', chromeMediaSourceId: streamId, maxWidth: 1920, maxHeight: 1080}, optional:[]};
  navigator.webkitGetUserMedia({audio: false, video: vid_cons}, success_func, fallback_func);
});
