### PR TITLE
Check for libnotify API version

### DIFF
--- a/src/nw_notification_manager_linux.cc
+++ b/src/nw_notification_manager_linux.cc
@@ -85,8 +85,18 @@ bool NotificationManagerLinux::AddDesktopNotification(const content::PlatformNot
   NotifyNotification * notif;
   NotificationMap::iterator i = getNotification(notification_id);
   if (i==mNotificationIDmap.end()) {
+#ifdef NOTIFY_CHECK_VERSION
+#if NOTIFY_CHECK_VERSION(0,7,0)
     notif = notify_notification_new (
       base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL);
+#else
+    notif = notify_notification_new (
+      base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL, NULL);
+#endif
+#else
+    notif = notify_notification_new (
+      base::UTF16ToUTF8(params.title).c_str(), base::UTF16ToUTF8(params.body).c_str(), NULL, NULL);
+#endif
     NotificationData data;
     data.mNotification = notif;
     data.mRenderProcessId = render_process_id;


### PR DESCRIPTION
If this looks familiar, it's the same as my old #2818 PR for CentOS 6 support, but that got left behind when the nw12 branch became the new master. I've rebased it on the new master.

Let me know if this should be merged into the nw12 branch instead.