### PR TITLE
Desktop capture monitor

### DIFF
--- a/nw.gypi
+++ b/nw.gypi
@@ -207,6 +207,8 @@
         'src/api/event/event.cc',
         'src/api/screen/desktop_capture_api.h',
         'src/api/screen/desktop_capture_api.cc',
+		'src/api/screen/desktop_capture_monitor.cc',
+        'src/api/screen/desktop_capture_monitor.h',
         '<(DEPTH)/chrome/browser/media/desktop_media_list.h',
         '<(DEPTH)/chrome/browser/media/desktop_media_list_observer.h',
         '<(DEPTH)/chrome/browser/media/desktop_media_picker.h',

--- a/src/api/dispatcher_host.cc
+++ b/src/api/dispatcher_host.cc
@@ -34,6 +34,7 @@
 #include "content/nw/src/api/menu/menu.h"
 #include "content/nw/src/api/menuitem/menuitem.h"
 #include "content/nw/src/api/screen/screen.h"
+#include "content/nw/src/api/screen/desktop_capture_monitor.h"
 #include "content/nw/src/api/shell/shell.h"
 #include "content/nw/src/api/shortcut/shortcut.h"
 #include "content/nw/src/api/tray/tray.h"
@@ -171,6 +172,8 @@ void DispatcherHost::OnAllocateObject(int object_id,
     objects_registry_.AddWithID(new Shortcut(object_id, weak_ptr_factory_.GetWeakPtr(), option), object_id);
   } else if (type == "Screen") {
     objects_registry_.AddWithID(new EventListener(object_id, weak_ptr_factory_.GetWeakPtr(), option), object_id);
+  }else if (type == "DesktopCaptureMonitor") {
+	  objects_registry_.AddWithID(new DesktopCaptureMonitor(object_id, weak_ptr_factory_.GetWeakPtr(), option), object_id);
   } else {
     LOG(ERROR) << "Allocate an object of unknown type: " << type;
     objects_registry_.AddWithID(new Base(object_id, weak_ptr_factory_.GetWeakPtr(), option), object_id);

--- a/src/api/screen/desktop_capture_monitor.cc
+++ b/src/api/screen/desktop_capture_monitor.cc
@@ -1,0 +1,144 @@
+// Copyright (c) 2012 Intel Corp
+// Copyright (c) 2012 The Chromium Authors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "content/nw/src/api/screen/desktop_capture_monitor.h"
+
+#include "base/values.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/strings/string16.h"
+#include "content/nw/src/api/dispatcher_host.h"
+#include "chrome/browser/media/desktop_streams_registry.h"
+#include "chrome/browser/media/media_capture_devices_dispatcher.h"
+
+#include "third_party/webrtc/modules/desktop_capture/desktop_capture_options.h"
+#include "third_party/webrtc/modules/desktop_capture/screen_capturer.h"
+#include "third_party/webrtc/modules/desktop_capture/window_capturer.h"
+
+#include "base/base64.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/gfx/image/image.h"
+#include "ui/gfx/image/image_skia.h"
+
+
+namespace nwapi {
+
+DesktopCaptureMonitor::DesktopCaptureMonitor(int id,
+	const base::WeakPtr<DispatcherHost>& dispatcher_host,
+	const base::DictionaryValue& option)
+	: Base(id, dispatcher_host, option) {
+}
+
+DesktopCaptureMonitor::~DesktopCaptureMonitor() {}
+
+
+void DesktopCaptureMonitor::CallSync(const std::string& method, const base::ListValue& arguments, base::ListValue* result){
+	if (method == "start") {
+		bool screens, windows;
+		if (arguments.GetBoolean(0, &screens) && arguments.GetBoolean(1, &windows))
+			Start(screens, windows);
+	}else if (method == "stop") {
+		Stop();
+	}
+	else {
+		NOTREACHED() << "Invalid call to DesktopCapture method:" << method
+			<< " arguments:" << arguments;
+	}
+}
+
+void DesktopCaptureMonitor::Start(bool screens, bool windows) {
+	webrtc::DesktopCaptureOptions options = webrtc::DesktopCaptureOptions::CreateDefault();
+	options.set_disable_effects(false);
+	scoped_ptr<webrtc::ScreenCapturer> screen_capturer(screens ? webrtc::ScreenCapturer::Create(options) : NULL);
+	scoped_ptr<webrtc::WindowCapturer> window_capturer(windows ? webrtc::WindowCapturer::Create(options) : NULL);
+
+	media_list_.reset(new NativeDesktopMediaList(screen_capturer.Pass(), window_capturer.Pass()));
+
+	media_list_->StartUpdating(this);
+}
+
+void DesktopCaptureMonitor::Stop() {
+	media_list_.reset();
+}
+
+void DesktopCaptureMonitor::OnSourceAdded(int index){
+	DesktopMediaList::Source src = media_list_->GetSource(index);
+	
+	std::string type;
+	if (src.id.type == content::DesktopMediaID::TYPE_AURA_WINDOW || src.id.type == content::DesktopMediaID::TYPE_WINDOW){
+		type = "window";
+	}
+	else if (src.id.type == content::DesktopMediaID::TYPE_SCREEN){
+		type = "screen";
+	}
+	else if (src.id.type == content::DesktopMediaID::TYPE_NONE){
+		type = "none";
+	}
+	else{
+		type = "unknown";
+	}
+
+	base::ListValue param;
+	param.AppendString(src.id.ToString());
+	param.AppendString(src.name);
+	param.AppendInteger(index);
+	param.AppendString(type);
+	this->dispatcher_host()->SendEvent(this, "__nw_desktop_capture_monitor_listner_added", param);
+}
+void DesktopCaptureMonitor::OnSourceRemoved(int index){
+	base::ListValue param;
+	param.AppendInteger(index); //pass by index here, because the information about which ID was at that index is lost before the removed callback is called.  Its saved in the javascript though, so we can look it up there
+	this->dispatcher_host()->SendEvent(this, "__nw_desktop_capture_monitor_listner_removed", param);
+}
+void DesktopCaptureMonitor::OnSourceMoved(int old_index, int new_index){
+	DesktopMediaList::Source src = media_list_->GetSource(new_index);
+	base::ListValue param;
+	param.AppendString(src.id.ToString());
+	param.AppendInteger(new_index);
+	param.AppendInteger(old_index);
+	this->dispatcher_host()->SendEvent(this, "__nw_desktop_capture_monitor_listner_moved", param);
+}
+void DesktopCaptureMonitor::OnSourceNameChanged(int index){
+	DesktopMediaList::Source src = media_list_->GetSource(index);
+
+	base::ListValue param;
+	param.AppendString(src.id.ToString());
+	param.AppendString(src.name);
+	this->dispatcher_host()->SendEvent(this, "__nw_desktop_capture_monitor_listner_namechanged", param);
+}
+
+void DesktopCaptureMonitor::OnSourceThumbnailChanged(int index){
+	std::string base64;
+
+	DesktopMediaList::Source src = media_list_->GetSource(index);
+	SkBitmap bitmap = src.thumbnail.GetRepresentation(1).sk_bitmap();
+	SkAutoLockPixels lock_image(bitmap);
+	std::vector<unsigned char> data;
+	bool success = gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false, &data);
+	if (success){
+		base::StringPiece raw_str(reinterpret_cast<const char*>(&data[0]), data.size());
+		base::Base64Encode(raw_str, &base64);
+	}
+	base::ListValue param;
+	param.AppendString(src.id.ToString());
+	param.AppendString(base64);
+	this->dispatcher_host()->SendEvent(this, "__nw_desktop_capture_monitor_listner_thumbnailchanged", param);
+}
+
+}  // namespace nwapi

--- a/src/api/screen/desktop_capture_monitor.h
+++ b/src/api/screen/desktop_capture_monitor.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2012 Intel Corp
+// Copyright (c) 2012 The Chromium Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#ifndef CONTENT_NW_SRC_API_DESKTOPCAPTURE_H_
+#define CONTENT_NW_SRC_API_DESKTOPCAPTURE_H_
+#include "base/compiler_specific.h"
+#include "content/nw/src/api/base/base.h"
+#include "chrome/browser/media/desktop_media_list_observer.h"
+#include "chrome/browser/media/native_desktop_media_list.h"
+
+namespace nwapi {
+	class DesktopCaptureMonitor : public Base, public DesktopMediaListObserver {
+		public:
+			DesktopCaptureMonitor(int id,
+				const base::WeakPtr<DispatcherHost>& dispatcher_host,
+				const base::DictionaryValue& option);
+			virtual ~DesktopCaptureMonitor();
+			virtual void CallSync(const std::string& method, const base::ListValue& arguments, base::ListValue* result) override;
+			virtual void OnSourceAdded(int index);
+			virtual void OnSourceRemoved(int index);
+			virtual void OnSourceMoved(int old_index, int new_index);
+			virtual void OnSourceNameChanged(int index);
+			virtual void OnSourceThumbnailChanged(int index);
+		private:
+			DesktopCaptureMonitor();
+			DISALLOW_COPY_AND_ASSIGN(DesktopCaptureMonitor);
+			void Start(bool screens, bool windows);
+			void Stop();
+			
+			scoped_ptr<DesktopMediaList> media_list_;
+	};
+} // namespace api
+#endif // CONTENT_NW_SRC_API_DESKTOPCAPTURE_H_

--- a/src/api/screen/screen.js
+++ b/src/api/screen/screen.js
@@ -18,11 +18,81 @@
 // ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+function DesktopCaptureMonitor() {
+    nw.allocateObject(this, {});
+    this.sources = new Array();
+    this.started = false;
+}
+require('util').inherits(DesktopCaptureMonitor, exports.Base);
+
+DesktopCaptureMonitor.prototype.start = function (screens, windows) {
+    if (this.started)
+        return false;
+    this.started = true;
+    nw.callObjectMethodSync(this, 'start', [screens, windows]);
+    return true;
+}
+
+DesktopCaptureMonitor.prototype.stop = function () {
+    if (!this.started)
+        return false;
+    nw.callObjectMethodSync(this, 'stop', []);
+    this.started = false;
+    this.sources = new Array();
+    return true;
+}
+
+DesktopCaptureMonitor.prototype.on('__nw_desktop_capture_monitor_listner_added', function (id, name, order, type) {
+    this.sources.splice(order, 0, id);
+    this.emit("added", id, name, order, type);
+    for (var i = order + 1; i <= this.sources.length - 1; i++) {
+        this.emit("orderchanged", this.sources[i], i, i - 1);
+    }
+});
+
+
+DesktopCaptureMonitor.prototype.on('__nw_desktop_capture_monitor_listner_removed', function (index) {
+    var id = this.sources[index];
+    if (index != -1) {
+        this.sources.splice(index, 1);
+        this.emit("removed", id);
+        for (var i = index; i <= this.sources.length - 1; i++) {
+            this.emit("orderchanged", this.sources[i], i, i + 1);
+        }
+    }
+});
+
+DesktopCaptureMonitor.prototype.on('__nw_desktop_capture_monitor_listner_moved', function (id, new_index, old_index) {
+    var temp = this.sources[old_index];
+    this.sources.splice(old_index, 1);
+    this.sources.splice(new_index, 0, temp);
+    this.emit("orderchanged", temp, new_index, old_index);
+    for (var i = new_index; i < old_index; i++)
+        this.emit("orderchanged", this.sources[i + 1], i + 1, i);
+});
+
+DesktopCaptureMonitor.prototype.on('__nw_desktop_capture_monitor_listner_namechanged', function (id, name) {
+    this.emit("namechanged", id, name);
+});
+
+DesktopCaptureMonitor.prototype.on('__nw_desktop_capture_monitor_listner_thumbnailchanged', function (id, thumbnail) {
+    this.emit("thumbnailchanged", id, thumbnail);
+});
+
+DesktopCaptureMonitor.prototype.on = DesktopCaptureMonitor.prototype.addListener = function (ev, callback) {
+    //throw except if unsupported event
+    if (ev != "added" && ev != "removed" && ev != "orderchanged" && ev != "namechanged" && ev != "thumbnailchanged")
+        throw new String("only following events can be listened: added, removed, moved, namechanged, thumbnailchanged");
+
+    process.EventEmitter.prototype.addListener.apply(this, arguments);
+}
+
 var screenInstance = null;
 
 function Screen() {
   nw.allocateObject(this, {});
   this._numListener = 0;
+  this.DesktopCaptureMonitor = new DesktopCaptureMonitor();
 }
 require('util').inherits(Screen, exports.Base);
 

--- a/src/nw_shell.cc
+++ b/src/nw_shell.cc
@@ -78,6 +78,7 @@
 using nw::NativeWindowAura;
 #endif
 #include "content/public/browser/media_capture_devices.h"
+#include "media/audio/audio_manager_base.h"
 
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "extensions/common/extension_messages.h"
@@ -722,6 +723,11 @@ void Shell::RequestMediaAccessPermission(
     devices.push_back(content::MediaStreamDevice(
                       content::MEDIA_DESKTOP_VIDEO_CAPTURE, media_id.ToString(), "Screen"));
   }
+#if defined(OS_WIN)
+  if (request.audio_type == content::MEDIA_DESKTOP_AUDIO_CAPTURE) {
+	  devices.push_back(content::MediaStreamDevice(content::MEDIA_DESKTOP_AUDIO_CAPTURE, media::AudioManagerBase::kLoopbackInputDeviceId, "System Audio"));
+  }
+#endif
   // TODO(jamescook): Should we show a recording icon somewhere? If so, where?
   scoped_ptr<MediaStreamUI> ui;
   callback.Run(devices,


### PR DESCRIPTION
This is API plumbing for the internal interfaces chrome uses to enumerate desktop capture streams and for getting their thumbnails. It allows for apps to implement their own desktop capture picker window in HTML/Javascript.

Here is a sample app that uses the API:
https://gist.github.com/redgecombe/835fe42b8308a0afaecc

gui.Screen.Init();
gui.Screen.DesktopCaptureMonitor.start(should_include_screens, should_include_monitors); //The screen capture API will monitor the system and trigger the below events.

To stop:
gui.Screen.DesktopCaptureMonitor.stop(); //The screen capture system will stop monitoring the system.

Events:
gui.Screen.DesktopCaptureMonitor.on("added", function (id, name, order, type) {
//id is unique id that can be passed as chromeMediaSourceId
//name is the title of the window or screen
//order is the z-order of the windows, if screens are selected they will appear first
//type of the stream: "screen", "window", "other" or "unknown"
});
gui.Screen.DesktopCaptureMonitor.on("removed", function (id) {
//the id of the screen or monitor that is no longer capturable
});
gui.Screen.DesktopCaptureMonitor.on("orderchanged", function (id, new_order, old_order) {
//id is the screen or window that has changed z-order
//new_order is the new z-order
//old_order is the old z-order
});
gui.Screen.DesktopCaptureMonitor.on("namechanged", function (id, name) {
//id is the screen or window that has changed title
//name is the title
});
gui.Screen.DesktopCaptureMonitor.on("thumbnailchanged", function (id, thumbnail) {
//id is the screen or window that has an updated thumbnail
//thumbnail is the base64 encoded png of the thumbnail
});