### PR TITLE
Use only instances of Error in throw statement

### DIFF
--- a/src/api/clipboard/clipboard.js
+++ b/src/api/clipboard/clipboard.js
@@ -30,7 +30,7 @@ Clipboard.prototype.set = function(data, type) {
     type = 'text';
 
   if (type != 'text')
-    throw new String("Type of '" + type + "' is not supported");
+    throw new TypeError("Type of '" + type + "' is not supported");
 
   nw.callObjectMethod(this, 'Set', [ data, type ]);
 }
@@ -40,7 +40,7 @@ Clipboard.prototype.get = function(type) {
     type = 'text';
 
   if (type != 'text')
-    throw new String('Only support getting plain text from Clipboard');
+    throw new TypeError('Only support getting plain text from Clipboard');
 
   var result = nw.callObjectMethodSync(this, 'Get', [ type ]);
   if (type == 'text')

--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -27,7 +27,7 @@ function Menu(option) {
     option = { type: 'contextmenu' };
 
   if (option.type != 'contextmenu' && option.type != 'menubar')
-    throw new String('Invalid menu type: ' + option.type);
+    throw new TypeError('Invalid menu type: ' + option.type);
 
   this.type = option.type;
   v8_util.setHiddenValue(this, 'items', []);
@@ -40,12 +40,12 @@ Menu.prototype.__defineGetter__('items', function() {
 });
 
 Menu.prototype.__defineSetter__('items', function(val) {
-  throw new String('Menu.items is immutable');
+  throw new Error('Menu.items is immutable');
 });
 
 Menu.prototype.append = function(menu_item) {
   if (v8_util.getConstructorName(menu_item) != 'MenuItem')
-    throw new String("Menu.append() requires a valid MenuItem");
+    throw new TypeError("Menu.append() requires a valid MenuItem");
     
   this.items.push(menu_item);
   nw.callObjectMethod(this, 'Append', [ menu_item.id ]);

--- a/src/api/menuitem/menuitem.js
+++ b/src/api/menuitem/menuitem.js
@@ -22,7 +22,7 @@ var v8_util = process.binding('v8_util');
 
 function MenuItem(option) {
   if (typeof option != 'object')
-    throw new String('Invalid option.');
+    throw new TypeError('Invalid option.');
 
   if (!option.hasOwnProperty('type'))
     option.type = 'normal';
@@ -30,14 +30,14 @@ function MenuItem(option) {
   if (option.type != 'normal' &&
       option.type != 'checkbox' &&
       option.type != 'separator')
-    throw new String('Invalid MenuItem type: ' + option.type);
+    throw new TypeError('Invalid MenuItem type: ' + option.type);
 
   if (option.type == 'normal' || option.type == 'checkbox') {
     if (option.type == 'checkbox')
       option.checked = Boolean(option.checked);
 
     if (!option.hasOwnProperty('label'))
-      throw new String('A normal MenuItem must have a label');
+      throw new TypeError('A normal MenuItem must have a label');
     else
       option.label = String(option.label);
 
@@ -59,7 +59,7 @@ function MenuItem(option) {
 
     if (option.hasOwnProperty('submenu')) {
       if (v8_util.getConstructorName(option.submenu) != 'Menu')
-        throw new String("'submenu' must be a valid Menu");
+        throw new TypeError("'submenu' must be a valid Menu");
 
       // Transfer only object id
       v8_util.setHiddenValue(this, 'submenu', option.submenu);
@@ -68,7 +68,7 @@ function MenuItem(option) {
 
     if (option.hasOwnProperty('click')) {
       if (typeof option.click != 'function')
-        throw new String("'click' must be a valid Function");
+        throw new TypeError("'click' must be a valid Function");
       else
         this.click = option.click;
     }
@@ -100,7 +100,7 @@ MenuItem.prototype.__defineGetter__('type', function() {
 });
 
 MenuItem.prototype.__defineSetter__('type', function() {
-  throw new String("'type' is immutable at runtime");
+  throw new Error("'type' is immutable at runtime");
 });
 
 MenuItem.prototype.__defineGetter__('label', function() {
@@ -162,7 +162,7 @@ MenuItem.prototype.__defineGetter__('checked', function() {
 
 MenuItem.prototype.__defineSetter__('checked', function(val) {
   if (this.type != 'checkbox')
-    throw new String("'checked' property is only available for checkbox");
+    throw new TypeError("'checked' property is only available for checkbox");
 
   this.handleSetter('checked', 'SetChecked', Boolean, val);
 });
@@ -181,7 +181,7 @@ MenuItem.prototype.__defineGetter__('submenu', function() {
 
 MenuItem.prototype.__defineSetter__('submenu', function(val) {
   if (v8_util.getConstructorName(val) != 'Menu')
-    throw new String("'submenu' property requries a valid Menu");
+    throw new TypeError("'submenu' property requries a valid Menu");
 
   v8_util.setHiddenValue(this, 'submenu', val);
   nw.callObjectMethod(this, 'SetSubmenu', [ val.id ]);

--- a/src/api/screen/screen.js
+++ b/src/api/screen/screen.js
@@ -29,7 +29,7 @@ require('util').inherits(Screen, exports.Base);
 // Override the addListener method.
 Screen.prototype.on = Screen.prototype.addListener = function(ev, callback) {
   if ( ev != "displayBoundsChanged" && ev != "displayAdded" && ev != "displayRemoved" && ev != "chooseDesktopMedia")
-    throw new String('only following event can be listened: displayBoundsChanged, displayAdded, displayRemoved');
+    throw new TypeError('only following event can be listened: displayBoundsChanged, displayAdded, displayRemoved');
   
   var onRemoveListener = function (type, listener) {
     if (this._numListener > 0) {
@@ -43,7 +43,7 @@ Screen.prototype.on = Screen.prototype.addListener = function(ev, callback) {
 
   if(this._numListener == 0) {
     if (nw.callStaticMethodSync('Screen', 'AddScreenChangeCallback', [ this.id ])[0] == false ) {
-      throw new String('nw.callStaticMethodSync(Screen, AddScreenChangeCallback) fails');
+      throw new Error('nw.callStaticMethodSync(Screen, AddScreenChangeCallback) fails');
       return;
     }
     process.EventEmitter.prototype.addListener.apply(this, ["removeListener", onRemoveListener]);

--- a/src/api/shortcut/shorcut.js
+++ b/src/api/shortcut/shorcut.js
@@ -22,7 +22,7 @@ var v8_util = process.binding('v8_util');
 
 function Shortcut(option) {
   if (typeof option != 'object')
-    throw new String('Invalid option.');
+    throw new TypeError('Invalid option.');
 
   if (!option.hasOwnProperty('key'))
     throw new TypeError("Shortcut requires 'key' to specify key combinations.");

--- a/src/api/tray/tray.js
+++ b/src/api/tray/tray.js
@@ -22,10 +22,10 @@ var v8_util = process.binding('v8_util');
 
 function Tray(option) {
   if (typeof option != 'object')
-    throw new String('Invalid option');
+    throw new TypeError('Invalid option');
 
   if (!option.hasOwnProperty('title') && !option.hasOwnProperty('icon'))
-    throw new String("Must set 'title' or 'icon' field in option");
+    throw new TypeError("Must set 'title' or 'icon' field in option");
 
   if (!option.hasOwnProperty('title'))
     option.title = '';
@@ -52,7 +52,7 @@ function Tray(option) {
 
   if (option.hasOwnProperty('click')) {
     if (typeof option.click != 'function') {
-      throw new String("'click' must be a valid Function");
+      throw new TypeError("'click' must be a valid Function");
     } else {
       this.click = option.click;
     }
@@ -60,7 +60,7 @@ function Tray(option) {
 
   if (option.hasOwnProperty('menu')) {
     if (v8_util.getConstructorName(option.menu) != 'Menu')
-      throw new String("'menu' must be a valid Menu");
+      throw new TypeError("'menu' must be a valid Menu");
 
     // Transfer only object id
     v8_util.setHiddenValue(this, 'menu', option.menu);
@@ -130,7 +130,7 @@ Tray.prototype.__defineGetter__('menu', function() {
 
 Tray.prototype.__defineSetter__('menu', function(val) {
   if (v8_util.getConstructorName(val) != 'Menu')
-    throw new String("'menu' property requries a valid Menu");
+    throw new TypeError("'menu' property requries a valid Menu");
 
   v8_util.setHiddenValue(this, 'menu', val);
   nw.callObjectMethod(this, 'SetMenu', [ val.id ]);

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -221,10 +221,10 @@ Window.prototype.__defineSetter__('menu', function(menu) {
     return;
   }
   if (v8_util.getConstructorName(menu) != 'Menu')
-    throw new String("'menu' property requries a valid Menu");
+    throw new TypeError("'menu' property requries a valid Menu");
 
   if (menu.type != 'menubar')
-    throw new String('Only menu of type "menubar" can be used as this.window menu');
+    throw new TypeError('Only menu of type "menubar" can be used as this.window menu');
 
   v8_util.setHiddenValue(this, 'menu', menu);
   CallObjectMethod(this, 'SetMenu', [ menu.id ]);
@@ -432,7 +432,7 @@ Window.prototype.setBadgeLabel = function(label) {
 
 Window.prototype.setProgressBar = function(progress) {
   if (typeof progress != "number")
-    throw new String('progress must be a number');
+    throw new TypeError('progress must be a number');
   CallObjectMethod(this, 'SetProgressBar', [ progress ]);
 }
   
@@ -442,7 +442,7 @@ Window.prototype.setTransparent = function(transparent) {
 
 Window.prototype.setPosition = function(position) {
   if (position != 'center' && position != 'mouse')
-    throw new String('Invalid postion');
+    throw new TypeError('Invalid postion');
   CallObjectMethod(this, 'SetPosition', [ position ]);
 }
 


### PR DESCRIPTION
Although in JavaScript anything can be thrown, it's much better to throw Errors, not just Strings. It's more semantic and debugger-friendly.