### PR TITLE
Fixed window size not working when using window.open

### DIFF
--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -132,6 +132,7 @@ std::wstring ASCIIToWide(const std::string& ascii) {
 Package::Package()
     : path_(GetSelfPath()),
       self_extract_(true) {
+
   // First try to extract self.
   if (InitFromPath())
     return;
@@ -343,8 +344,11 @@ void Package::InitWithDefault() {
   root_.reset(new base::DictionaryValue());
   root()->SetString(switches::kmName, "node-webkit");
   root()->SetString(switches::kmMain, "nw:blank");
+  root()->Set(switches::kmWindow, GetNewWindow());
+}
+
+base::DictionaryValue* Package::GetNewWindow() {
   base::DictionaryValue* window = new base::DictionaryValue();
-  root()->Set(switches::kmWindow, window);
 
   // Hide toolbar if specifed in the command line.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kNoToolbar))
@@ -352,6 +356,8 @@ void Package::InitWithDefault() {
 
   // Window should show in center by default.
   window->SetString(switches::kmPosition, "center");
+
+  return window;
 }
 
 bool Package::ExtractPath() {

--- a/src/nw_package.h
+++ b/src/nw_package.h
@@ -83,6 +83,8 @@ class Package {
   // Manifest string.
   std::string package_string() { return package_string_; }
 
+  base::DictionaryValue* GetNewWindow();
+
  private:
   bool InitFromPath();
   void InitWithDefault();

--- a/src/nw_shell.cc
+++ b/src/nw_shell.cc
@@ -587,27 +587,36 @@ void Shell::WebContentsCreated(WebContents* source_contents,
                                const GURL& target_url,
                                WebContents* new_contents,
                                const base::string16& nw_window_manifest) {
+
+  bool overwrite_manifest = true;
+
   // Create with package's manifest
   scoped_ptr<base::DictionaryValue> manifest(
-      GetPackage()->window()->DeepCopy());
+      GetPackage()->GetNewWindow());
 
   scoped_ptr<base::Value> val;
   std::string manifest_str = base::UTF16ToUTF8(nw_window_manifest);
   val.reset(base::JSONReader().ReadToValue(manifest_str));
-  if (val.get() && val->IsType(base::Value::TYPE_DICTIONARY))
+  if (val.get() && val->IsType(base::Value::TYPE_DICTIONARY)) {
     manifest.reset(static_cast<base::DictionaryValue*>(val.release()));
+    overwrite_manifest = false;
+  }
 
   // Get window features
   blink::WebWindowFeatures features = new_contents->GetWindowFeatures();
-  manifest->SetBoolean(switches::kmResizable, features.resizable);
-  manifest->SetBoolean(switches::kmFullscreen, features.fullscreen);
-  if (features.widthSet)
+  if (overwrite_manifest || !manifest->HasKey(switches::kmResizable))
+    manifest->SetBoolean(switches::kmResizable, features.resizable);
+  if (overwrite_manifest || !manifest->HasKey(switches::kmFullscreen))
+    manifest->SetBoolean(switches::kmFullscreen, features.fullscreen);
+  if (overwrite_manifest || !manifest->HasKey(switches::kmToolbar))
+    manifest->SetBoolean(switches::kmToolbar, features.toolBarVisible);
+  if (features.widthSet && (overwrite_manifest || !manifest->HasKey(switches::kmWidth)))
     manifest->SetInteger(switches::kmWidth, features.width);
-  if (features.heightSet)
+  if (features.heightSet && (overwrite_manifest || !manifest->HasKey(switches::kmHeight)))
     manifest->SetInteger(switches::kmHeight, features.height);
-  if (features.xSet)
+  if (features.xSet && (overwrite_manifest || !manifest->HasKey(switches::kmX)))
     manifest->SetInteger(switches::kmX, features.x);
-  if (features.ySet)
+  if (features.ySet && (overwrite_manifest || !manifest->HasKey(switches::kmY)))
     manifest->SetInteger(switches::kmY, features.y);
   // window.open should show the window by default.
   manifest->SetBoolean(switches::kmShow, true);


### PR DESCRIPTION
Partial fix for nwjs/nw.js#2868

With this patch, the 3rd parameter of `window.open(url, target, features)` will work as expected. Same parameters in `features` will be overwritten by manifest set via `policy.setNewWindowManifest()` in `new-win-policy`.

**Behavior changes from nw12**: new windows does **NOT** inherit from parent window's manifest, but from a default manifest:
* `"toolbar"` is set to `false` if has command line parameter `--no-toolbar`
* `"position"` is `"center"`