### PR TITLE
Added --app-path for chromedriver nwjs/nw.js#3167

### DIFF
--- a/src/common/shell_switches.cc
+++ b/src/common/shell_switches.cc
@@ -34,6 +34,9 @@ const char kNoToolbar[] = "no-toolbar";
 // Open specified url
 const char kUrl[] = "url";
 
+// Specified app location
+const char kAppPath[] = "app-path";
+
 // Set current working directory.
 const char kWorkingDirectory[] = "working-directory";
 

--- a/src/common/shell_switches.h
+++ b/src/common/shell_switches.h
@@ -18,6 +18,7 @@ extern const char kContentShellDataPath[];
 extern const char kDeveloper[];
 extern const char kNoToolbar[];
 extern const char kUrl[];
+extern const char kAppPath[];
 extern const char kWorkingDirectory[];
 extern const char kNodeMain[];
 extern const char kSnapshot[];

--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -151,7 +151,15 @@ Package::Package()
     return;
 
   // Then see if we have arguments and extract it.
+  // check --app-path first
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if(command_line->HasSwitch(switches::kAppPath)) {
+    path_ = command_line->GetSwitchValuePath(switches::kAppPath);
+  }
+  if (InitFromPath())
+    return;
+
+  // then treat first argument as path
   const base::CommandLine::StringVector& args = command_line->GetArgs();
   if (args.size() > 0) {
     self_extract_ = false;


### PR DESCRIPTION
`--app-path` is used for specifying path of app for nw.js. It's
added for chromedriver since chromedriver doesn't allow providing
raw arguments to nw.