### PR TITLE
Update nwjs location for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Note: on Windows, you can drag the folder containing `package.json` to `nw.exe` 
 
 Note: on OSX, the executable binary is in a hidden directory within the .app file. To run node-webkit on OSX, type:
 ```bash
-$ /path/to/node-webkit.app/Contents/MacOS/node-webkit .  (suppose the current directory contains 'package.json')
+$ /path/to/nwjs.app/Contents/MacOS/nwjs .  (suppose the current directory contains 'package.json')
 ```
 ## Documents
 


### PR DESCRIPTION
Updates the README.md Quickstart with updated path for OSX apps.