### PR TITLE
More precise RegExp for App.argv filtering

### DIFF
--- a/src/api/app/app.js
+++ b/src/api/app/app.js
@@ -26,10 +26,10 @@ function App() {
 require('util').inherits(App, exports.Base);
 
 App.filteredArgv = [
-  /--no-toolbar/,
-  /--url=.*/,
-  /--remote-debugging-port=.*/,
-  /--renderer-cmd-prefix.*/,
+  /^--no-toolbar$/,
+  /^--url=/,
+  /^--remote-debugging-port=/,
+  /^--renderer-cmd-prefix/,
 ];
 
 App.prototype.quit = function() {


### PR DESCRIPTION
Currently regexps are too greedy and can erroneously filter out command line args that aren't nw.js keys. For example, `--my--url=…` and `final--no-toolbar.png`.

Also, trailing “match-anything” `.*` were removed as it doesn't affect the `Regexp::test` behavior.
