### PR TITLE
Correct Mac OS X example app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ $ /path/to/nw .  (suppose the current directory contains 'package.json')
 
 Note: on Windows, you can drag the folder containing `package.json` to `nw.exe` to open it.
 
-Note: on OSX, the executable binary is in a hidden directory within the .app file. To run node-webkit on OSX, type:
-```bash
-$ /path/to/node-webkit.app/Contents/MacOS/node-webkit .  (suppose the current directory contains 'package.json')
-```
+Note: on OSX, the executable binary is in a hidden directory within the .app file. To run node-webkit on OSX, type:  
+`/path/to/nwjs.app/Contents/MacOS/nwjs .` *(suppose the current directory contains 'package.json')*   
+
 ## Documents
 
 For more information on how to write/package/run apps, see:


### PR DESCRIPTION
App-name did not match in readme + removed comment from code-block.