### PR TITLE
Fix #1164: window doesn't display correct title when navigating back and...

### DIFF
--- a/src/nw_shell.cc
+++ b/src/nw_shell.cc
@@ -356,12 +356,18 @@ void Shell::LoadURL(const GURL& url) {
   //     PAGE_TRANSITION_TYPED,
   //     std::string());
   web_contents_->Focus();
+  std::string title = UTF16ToUTF8(
+      web_contents_->GetController().GetActiveEntry()->GetTitle());
+  window()->SetTitle(title.empty() ? "Untitled" : title);
   window()->SetToolbarButtonEnabled(nw::NativeWindow::BUTTON_FORWARD, false);
 }
 
 void Shell::GoBackOrForward(int offset) {
   web_contents_->GetController().GoToOffset(offset);
   web_contents_->Focus();
+  std::string title = UTF16ToUTF8(
+      web_contents_->GetController().GetActiveEntry()->GetTitle());
+  window()->SetTitle(title.empty() ? "Untitled" : title);
 }
 
 void Shell::Reload(ReloadType type) {


### PR DESCRIPTION
... forward

NativeWindow's title should update with the current navigation's entry in real
time on response to navigation button and url text fields update.

@rogerwang   please spare time to help review, thanks.
In this PR, choose navigation entry to fetch real time title is more reliable. Except 1st opened window title is set from package.json, window title is updated with user's navigation in real time especially on cross-site navigating. Currently display the appropriate "Untitled" label if the title tag is not defined in pages.