### PR TITLE
Added mandatory version to package.json example in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Create `package.json`:
 ```json
 {
   "name": "nw-demo",
+  "version": "0.0.1",
   "main": "index.html"
 }
 ```


### PR DESCRIPTION
Countering the error: "Please make sure that your project's package.json includes a
version and a name value" while starting with `nwbuild -r .`.