### PR TITLE
Removed 'JavaScript' from title of JavaScript dialogs in Linux

### DIFF
--- a/src/browser/shell_javascript_dialog_gtk.cc
+++ b/src/browser/shell_javascript_dialog_gtk.cc
@@ -91,7 +91,7 @@ ShellJavaScriptDialog::ShellJavaScriptDialog(
                    "delete-event",
                    G_CALLBACK(gtk_widget_hide_on_delete),
                    NULL);
-  gtk_window_set_title(GTK_WINDOW(gtk_dialog_), "JavaScript");
+  gtk_window_set_title(GTK_WINDOW(gtk_dialog_), "");
 
   GtkWidget* ok_button = gtk_dialog_add_button(GTK_DIALOG(gtk_dialog_),
                                                GTK_STOCK_OK,


### PR DESCRIPTION
Pull request for issue #3430 