### PR TITLE
Renamed `nw.Object` to `nw.Obj` to avoid conflict

### DIFF
--- a/src/api/_api_features.json
+++ b/src/api/_api_features.json
@@ -27,7 +27,7 @@
     "channel": "stable",
     "contexts": ["blessed_extension"]
   },
-  "nw.Object": {
+  "nw.Obj": {
     "channel": "stable",
     "contexts": ["blessed_extension"]
   },

--- a/src/api/nw_object.idl
+++ b/src/api/nw_object.idl
@@ -4,7 +4,7 @@
 
 // nw Object API
 [implemented_in="content/nw/src/api/nw_object_api.h"]
-namespace nw.Object {
+namespace nw.Obj {
   interface Functions {
     static object create(long id, DOMString type, object options);
     static object destroy(long id);

--- a/src/api/nw_object_api.cc
+++ b/src/api/nw_object_api.cc
@@ -12,13 +12,13 @@
 
 namespace extensions {
 
-NwObjectCreateFunction::NwObjectCreateFunction() {
+NwObjCreateFunction::NwObjCreateFunction() {
 }
 
-NwObjectCreateFunction::~NwObjectCreateFunction() {
+NwObjCreateFunction::~NwObjCreateFunction() {
 }
 
-bool NwObjectCreateFunction::RunNWSync(base::ListValue* response, std::string* error) {
+bool NwObjCreateFunction::RunNWSync(base::ListValue* response, std::string* error) {
   base::DictionaryValue* options = nullptr;
   int id = 0;
   std::string type;
@@ -31,13 +31,13 @@ bool NwObjectCreateFunction::RunNWSync(base::ListValue* response, std::string* e
   return true;
 }
 
-NwObjectDestroyFunction::NwObjectDestroyFunction() {
+NwObjDestroyFunction::NwObjDestroyFunction() {
 }
 
-NwObjectDestroyFunction::~NwObjectDestroyFunction() {
+NwObjDestroyFunction::~NwObjDestroyFunction() {
 }
 
-bool NwObjectDestroyFunction::RunNWSync(base::ListValue* response, std::string* error) {
+bool NwObjDestroyFunction::RunNWSync(base::ListValue* response, std::string* error) {
   int id = 0;
   EXTENSION_FUNCTION_VALIDATE(args_->GetInteger(0, &id));
 
@@ -46,13 +46,13 @@ bool NwObjectDestroyFunction::RunNWSync(base::ListValue* response, std::string* 
   return true;
 }
 
-NwObjectCallObjectMethodFunction::NwObjectCallObjectMethodFunction() {
+NwObjCallObjectMethodFunction::NwObjCallObjectMethodFunction() {
 }
 
-NwObjectCallObjectMethodFunction::~NwObjectCallObjectMethodFunction() {
+NwObjCallObjectMethodFunction::~NwObjCallObjectMethodFunction() {
 }
 
-bool NwObjectCallObjectMethodFunction::RunNWSync(base::ListValue* response, std::string* error) {
+bool NwObjCallObjectMethodFunction::RunNWSync(base::ListValue* response, std::string* error) {
   base::ListValue* arguments = nullptr;
   int id = 0;
   std::string type, method;
@@ -66,13 +66,13 @@ bool NwObjectCallObjectMethodFunction::RunNWSync(base::ListValue* response, std:
   return true;
 }
 
-NwObjectCallObjectMethodSyncFunction::NwObjectCallObjectMethodSyncFunction() {
+NwObjCallObjectMethodSyncFunction::NwObjCallObjectMethodSyncFunction() {
 }
 
-NwObjectCallObjectMethodSyncFunction::~NwObjectCallObjectMethodSyncFunction() {
+NwObjCallObjectMethodSyncFunction::~NwObjCallObjectMethodSyncFunction() {
 }
 
-bool NwObjectCallObjectMethodSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
+bool NwObjCallObjectMethodSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
   base::ListValue* arguments = nullptr;
   int id = 0;
   std::string type, method;

--- a/src/api/nw_object_api.h
+++ b/src/api/nw_object_api.h
@@ -7,56 +7,56 @@
 
 namespace extensions {
 
-class NwObjectCreateFunction : public NWSyncExtensionFunction {
+class NwObjCreateFunction : public NWSyncExtensionFunction {
  public:
-  NwObjectCreateFunction();
+  NwObjCreateFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwObjectCreateFunction() override;
+  ~NwObjCreateFunction() override;
 
-  DECLARE_EXTENSION_FUNCTION("nw.Object.create", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Obj.create", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwObjectCreateFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwObjCreateFunction);
 };
 
-class NwObjectDestroyFunction : public NWSyncExtensionFunction {
+class NwObjDestroyFunction : public NWSyncExtensionFunction {
  public:
-  NwObjectDestroyFunction();
+  NwObjDestroyFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwObjectDestroyFunction() override;
+  ~NwObjDestroyFunction() override;
 
-  DECLARE_EXTENSION_FUNCTION("nw.Object.destroy", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Obj.destroy", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwObjectDestroyFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwObjDestroyFunction);
 };
 
-class NwObjectCallObjectMethodFunction : public NWSyncExtensionFunction {
+class NwObjCallObjectMethodFunction : public NWSyncExtensionFunction {
  public:
-  NwObjectCallObjectMethodFunction();
+  NwObjCallObjectMethodFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwObjectCallObjectMethodFunction() override;
+  ~NwObjCallObjectMethodFunction() override;
 
-  DECLARE_EXTENSION_FUNCTION("nw.Object.callObjectMethod", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Obj.callObjectMethod", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwObjectCallObjectMethodFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwObjCallObjectMethodFunction);
 };
 
-class NwObjectCallObjectMethodSyncFunction : public NWSyncExtensionFunction {
+class NwObjCallObjectMethodSyncFunction : public NWSyncExtensionFunction {
  public:
-  NwObjectCallObjectMethodSyncFunction();
+  NwObjCallObjectMethodSyncFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwObjectCallObjectMethodSyncFunction() override;
+  ~NwObjCallObjectMethodSyncFunction() override;
 
-  DECLARE_EXTENSION_FUNCTION("nw.Object.callObjectMethodSync", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Obj.callObjectMethodSync", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwObjectCallObjectMethodSyncFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwObjCallObjectMethodSyncFunction);
 };
 
 } // namespace extensions

--- a/src/resources/api_nw_menu.js
+++ b/src/resources/api_nw_menu.js
@@ -29,27 +29,27 @@ Menu.prototype.__defineSetter__('items', function(val) {
 
 Menu.prototype.append = function(menu_item) {
   privates(this).items.push(menu_item);
-  nw.Object.callObjectMethod(this.id, 'Menu', 'Append', [ menu_item.id ]);
+  nw.Obj.callObjectMethod(this.id, 'Menu', 'Append', [ menu_item.id ]);
 };
 
 Menu.prototype.insert = function(menu_item, i) {
   privates(this).items.splice(i, 0, menu_item);
-  nw.Object.callObjectMethod(this.id, 'Menu', 'Insert', [ menu_item.id, i ]);
+  nw.Obj.callObjectMethod(this.id, 'Menu', 'Insert', [ menu_item.id, i ]);
 }
 
 Menu.prototype.remove = function(menu_item) {
   var pos_hint = privates(this).items.indexOf(menu_item);
-  nw.Object.callObjectMethod(this.id, 'Menu', 'Remove', [ menu_item.id, pos_hint ]);
+  nw.Obj.callObjectMethod(this.id, 'Menu', 'Remove', [ menu_item.id, pos_hint ]);
   privates(this).items.splice(pos_hint, 1);
 }
 
 Menu.prototype.removeAt = function(i) {
-  nw.Object.callObjectMethod(this.id, 'Menu', 'Remove', [ privates(this).items[i].id, i ]);
+  nw.Obj.callObjectMethod(this.id, 'Menu', 'Remove', [ privates(this).items[i].id, i ]);
   privates(this).items.splice(i, 1);
 }
 
 Menu.prototype.popup = function(x, y) {
-  nw.Object.callObjectMethod(this.id, 'Menu', 'Popup', [ x, y ]);
+  nw.Obj.callObjectMethod(this.id, 'Menu', 'Popup', [ x, y ]);
 }
 
 Menu.prototype.createMacBuiltin = function (app_name, options) {
@@ -246,7 +246,7 @@ MenuItem.prototype.handleGetter = function(name) {
 MenuItem.prototype.handleSetter = function(name, setter, type, value) {
   value = type(value);
   privates(this).option[name] = value;
-  nw.Object.callObjectMethod(this.id, 'MenuItem', setter, [ value ]);
+  nw.Obj.callObjectMethod(this.id, 'MenuItem', setter, [ value ]);
 };
 
 MenuItem.prototype.__defineGetter__('type', function() {
@@ -335,7 +335,7 @@ MenuItem.prototype.__defineGetter__('submenu', function() {
 
 MenuItem.prototype.__defineSetter__('submenu', function(val) {
   privates(this).submenu = val;
-  nw.Object.callObjectMethod(this.id, 'MenuItem', 'SetSubmenu', [ val.id ]);
+  nw.Obj.callObjectMethod(this.id, 'MenuItem', 'SetSubmenu', [ val.id ]);
 });
 
 nw_binding.registerCustomHook(function(bindingsAPI) {
@@ -355,7 +355,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
     return ret;
   });
   apiFunctions.setHandleRequest('destroy', function(id) {
-    sendRequest.sendRequestSync('nw.Object.destroy', [id], this.definition.parameters, {});
+    sendRequest.sendRequestSync('nw.Obj.destroy', [id], this.definition.parameters, {});
   });
   apiFunctions.setHandleRequest('createMenu', function(option) {
     var id = contextMenuNatives.GetNextContextMenuId();
@@ -364,7 +364,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
 
     option.generatedId = id;
     var ret = new Menu(id, option);
-    sendRequest.sendRequestSync('nw.Object.create', [id, 'Menu', option], this.definition.parameters, {});
+    sendRequest.sendRequestSync('nw.Obj.create', [id, 'Menu', option], this.definition.parameters, {});
     messagingNatives.BindToGC(ret, nw.Menu.destroy.bind(undefined, id), -1);
     return ret;
   });

--- a/src/resources/api_nw_object.js
+++ b/src/resources/api_nw_object.js
@@ -1,6 +1,6 @@
 var Binding = require('binding').Binding;
 var forEach = require('utils').forEach;
-var nw_binding = require('binding').Binding.create('nw.Object');
+var nw_binding = require('binding').Binding.create('nw.Obj');
 var sendRequest = require('sendRequest');
 
 nw_binding.registerCustomHook(function(bindingsAPI) {

--- a/src/resources/api_nw_tray.js
+++ b/src/resources/api_nw_tray.js
@@ -75,7 +75,7 @@ Tray.prototype.handleGetter = function(name) {
 Tray.prototype.handleSetter = function(name, setter, type, value) {
   value = type(value);
   privates(this).option[name] = value;
-  nw.Object.callObjectMethod(this.id, 'Tray', setter, [ value ]);
+  nw.Obj.callObjectMethod(this.id, 'Tray', setter, [ value ]);
 };
 
 Tray.prototype.__defineGetter__('title', function() {
@@ -131,13 +131,13 @@ Tray.prototype.__defineSetter__('menu', function(val) {
     throw new TypeError("'menu' property requries a valid Menu");
 
   privates(this).menu = val;
-  nw.Object.callObjectMethod(this.id, 'Tray', 'SetMenu', [ val.id ]);
+  nw.Obj.callObjectMethod(this.id, 'Tray', 'SetMenu', [ val.id ]);
 });
 
 Tray.prototype.remove = function() {
   if (trayEvents.objs[this.id])
     this.removeListener('click');
-  nw.Object.callObjectMethod(this.id, 'Tray', 'Remove', []);
+  nw.Obj.callObjectMethod(this.id, 'Tray', 'Remove', []);
 }
 
 Tray.prototype.on = function (event, callback) {
@@ -163,7 +163,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
     trayEvents.objs[id]._onclick();
   });
   apiFunctions.setHandleRequest('destroy', function(id) {
-    sendRequest.sendRequestSync('nw.Object.destroy', [id], this.definition.parameters, {});
+    sendRequest.sendRequestSync('nw.Obj.destroy', [id], this.definition.parameters, {});
   });
   apiFunctions.setHandleRequest('create', function(option) {
     var id = contextMenuNatives.GetNextContextMenuId();
@@ -172,7 +172,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
 
     option.generatedId = id;
     var ret = new Tray(id, option);
-    sendRequest.sendRequestSync('nw.Object.create', [id, 'Tray', option], this.definition.parameters, {});
+    sendRequest.sendRequestSync('nw.Obj.create', [id, 'Tray', option], this.definition.parameters, {});
     messagingNatives.BindToGC(ret, nw.Tray.destroy.bind(undefined, id), -1);
     return ret;
   });


### PR DESCRIPTION
On Mac, `nw.Object` is overwritten by global `Object` object. Since `nw` holds all globals of Node context, I suggest to rename `nw.Object` to `nw.Obj` to avoid conflict with global variables.