### PR TITLE
Accept array of matched patterns in `node-remote`

### DIFF
--- a/docs/References/Manifest Format.md
+++ b/docs/References/Manifest Format.md
@@ -83,7 +83,7 @@ The following placeholders are available to composite the user agent dynamically
 !!! warning "Behavior Changed"
     This feature is changed in 0.13.0. See [Migration Notes from 0.12 to 0.13](../For Users/Migration/From 0.12 to 0.13.md).
 
-* `{Array}` Enable calling Node in remote pages. The value controls for which sites this feature should be turned on. Each item in the array follows the [match patterns](https://developer.chrome.com/extensions/match_patterns) used in Chrome extension.
+* `{Array}` or `{String}` Enable calling Node in remote pages. The value controls for which sites this feature should be turned on. Each item in the array follows the [match patterns](https://developer.chrome.com/extensions/match_patterns) used in Chrome extension.
 
 A match pattern is essentially a URL that begins with a permitted scheme (`http`, `https`, `file`, or `ftp`, and that can contain `'*'` characters. The special pattern `<all_urls>` matches any URL that starts with a permitted scheme. Each match pattern has 3 parts:
 

--- a/test/remoting/node-remote-array/http-server.py
+++ b/test/remoting/node-remote-array/http-server.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import SimpleHTTPServer
+import SocketServer
+import sys
+
+PORT = int(sys.argv[1])
+
+Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+
+httpd = SocketServer.TCPServer(("", PORT), Handler)
+
+print "serving at port", PORT
+httpd.serve_forever()
+

--- a/test/remoting/node-remote-array/index.html
+++ b/test/remoting/node-remote-array/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8">
+    <title>node-remote test</title>
+  </head>
+  <body>
+    <h1 id='result'>node-remote test</h1>
+    <script>
+      if (typeof nw === 'object') {
+        document.getElementById('result').innerHTML = 'success';
+      } else {
+        document.getElementById('result').innerHTML = 'fail: ' + typeof nw;
+      }
+    </script>
+  </body>
+</html>
+    

--- a/test/remoting/node-remote-array/test.py
+++ b/test/remoting/node-remote-array/test.py
@@ -1,0 +1,38 @@
+import time
+import os
+import subprocess
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common import utils
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(testdir)
+
+port = str(utils.free_port())
+server = subprocess.Popen(['python', 'http-server.py', port])
+
+manifest = open('package.json', 'w')
+manifest.write('''
+{
+  "name":"test-node-remote",
+  "node-remote":["<all_urls>"],
+  "main":"http://localhost:%s/index.html"
+}
+''' % (port))
+manifest.close()
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])
+try:
+    print driver.current_url
+    time.sleep(1)
+    result = driver.find_element_by_id('result')
+    print result.get_attribute('innerHTML')
+    assert("success" in result.get_attribute('innerHTML'))
+finally:
+    server.terminate()
+    driver.quit()
+


### PR DESCRIPTION
`node-remote` can accept string or array of matched patterns, like `['https://*.google.com/*', 'https://*.github.com/*']`.