### PR TITLE
Updated year in licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2012-2014 Intel Corp
-Copyright (c) 2012-2014 The Chromium Authors
+Copyright (c) 2012-2016 Intel Corp
+Copyright (c) 2012-2016 The Chromium Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in th


### PR DESCRIPTION
Fix outdated copyright year (updated to 2016).
The copyright year was out of date. Copyright notices must reflect the current year, so this commit updates the listed year to 2016.

See http://www.copyright.gov/circs/circ01.pdf for more info.