### PR TITLE
Reversed `x` and `y` in `win.moveTo` and `win.moveBy`

### DIFF
--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -349,12 +349,12 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
       this.appWindow.outerBounds.height += height;
     };
     NWWindow.prototype.moveTo = function (x, y) {
-      this.appWindow.outerBounds.top = x;
-      this.appWindow.outerBounds.left = y;
+      this.appWindow.outerBounds.left = x;
+      this.appWindow.outerBounds.top = y;
     };
     NWWindow.prototype.moveBy = function (x, y) {
-      this.appWindow.outerBounds.top += x;
-      this.appWindow.outerBounds.left += y;
+      this.appWindow.outerBounds.left += x;
+      this.appWindow.outerBounds.top += y;
     };
     NWWindow.prototype.setResizable = function (resizable) {
       this.appWindow.setResizable(resizable);


### PR DESCRIPTION
Fixed #4136