### PR TITLE
Remove debugger id index for Node

### DIFF
--- a/src/nw_content.cc
+++ b/src/nw_content.cc
@@ -438,7 +438,6 @@ void ContextCreationHook(blink::WebLocalFrame* frame, ScriptContext* context) {
         g_set_node_context_fn(isolate, &dom_context);
       dom_context->SetSecurityToken(v8::String::NewFromUtf8(isolate, "nw-token"));
       dom_context->Enter();
-      dom_context->SetEmbedderData(0, v8::String::NewFromUtf8(isolate, "node"));
 
       g_start_nw_instance_fn(argc, argv, dom_context);
       {


### PR DESCRIPTION
In separate mode, the Node context is created within the context of
background page. Overwrite the debugger id will cause debugger filter
out the compiled scripts from Node.

Fixed #4121