### PR TITLE
test case for `win.move()`

### DIFF
--- a/test/remoting/win-move/index.html
+++ b/test/remoting/win-move/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>win-move</title>
+</head>
+<body>
+  <button type="button" id="moveto" onclick="moveto(400,200)">move to (400, 200)</button>
+  <button type="button" id="moveby" onclick="moveby(400,200)">move by (400, 200)</button>
+  <script>
+  function out(id, msg) {
+    var h1 = document.createElement('h1');
+    h1.setAttribute('id', id);
+    h1.innerHTML = msg;
+    document.body.appendChild(h1);
+  }
+  function moveto(x,y) {
+    var win = nw.Window.get();
+    win.moveTo(x,y);
+
+    setTimeout(function() {  
+      if (win.x === x && win.y === y) {
+        out('moveto-result', 'success');
+      } else {
+        out('moveto-result', 'failed:' + [win.x, win.y].join(','));
+      }
+    }, 1000);
+  }
+  function moveby(x,y) {
+    var win = nw.Window.get();
+    var cx = win.x;
+    var cy = win.y;
+    win.moveBy(x,y);
+
+    setTimeout(function() {
+      if (win.x === cx + x && win.y === cy + y) {
+        out('moveby-result', 'success');
+      } else {
+        out('moveby-result', 'failed:' + [win.x, win.y].join(','));
+      }
+    }, 1000);
+  }
+  </script>
+</body>
+</html>

--- a/test/remoting/win-move/package.json
+++ b/test/remoting/win-move/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "win-move",
+  "main": "index.html"
+}

--- a/test/remoting/win-move/test.py
+++ b/test/remoting/win-move/test.py
@@ -1,0 +1,31 @@
+import time
+import os
+import platform
+import sys
+
+if platform.system() == 'Linux':
+  print 'Skiping win-move because of upstream issue. See nwjs/nw.js#4217.'
+  sys.exit(0)
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options)
+driver.implicitly_wait(10)
+time.sleep(1)
+try:
+    print driver.current_url
+    driver.find_element_by_id('moveto').click()
+    result = driver.find_element_by_id('moveto-result').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+
+    driver.find_element_by_id('moveby').click()
+    result = driver.find_element_by_id('moveby-result').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+finally:
+    driver.quit()


### PR DESCRIPTION
related to issue #4136 

This case is skipped for Linux because of an upstream issue. See #4217 .