### PR TITLE
test case for issue #4171

### DIFF
--- a/test/remoting/issue4171-win-close-event/index.html
+++ b/test/remoting/issue4171-win-close-event/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>win close event</title>
+</head>
+<body>
+  <h1>Try Close</h1>
+  <script>
+  var count = 3;
+  var win = nw.Window.get();
+  win.on('close', function() {
+    if (--count === 0) {
+      win.close(true);
+    } else {
+      out('result-' + count, 'success:' + count);
+    }
+  });
+
+  function out(id, msg) {
+    var h1 = document.createElement('h1');
+    h1.setAttribute('id', id);
+    h1.innerHTML = msg;
+    document.body.appendChild(h1);
+  }
+
+  function pos() {
+    return [win.x, win.y, win.width, win.height].join(',')
+  }
+  </script>
+</body>
+</html>

--- a/test/remoting/issue4171-win-close-event/package.json
+++ b/test/remoting/issue4171-win-close-event/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue4171-win-close-event",
+  "main": "index.html"
+}

--- a/test/remoting/issue4171-win-close-event/test.py
+++ b/test/remoting/issue4171-win-close-event/test.py
@@ -1,0 +1,50 @@
+import time
+import os
+import pyautogui
+import platform
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+def click_close():
+    pos = map(int, driver.execute_script('return pos()').split(','))
+    system = platform.system()
+    if system == 'Linux':
+        # close button on top/left. top offset is buggy (see `win-move`)
+        x = pos[0] + 10
+        y = pos[1] - 10
+    elif system == 'Windows':
+        # close button on top/right
+        x = pos[0] + pos[2] - 10
+        y = pos[1] + 10
+    elif system == 'Darwin':
+        # close button on top/left
+        x = pos[0] + 10
+        y = pos[1] + 10
+    else:
+        print 'Skip for unsupported platform %s' % system
+        return
+    print 'window pos: (%d, %d)' % (pos[0], pos[1])
+    print 'window size: (%d, %d)' % (pos[2], pos[3])
+    print 'click close at (%d, %d)' % (x, y)
+    pyautogui.click(x, y)
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options)
+driver.implicitly_wait(5)
+time.sleep(1)
+try:
+    print driver.current_url
+    click_close()
+    result = driver.find_element_by_id('result-2').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+    click_close()
+    result = driver.find_element_by_id('result-1').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+    driver.close()
+finally:
+    driver.quit()


### PR DESCRIPTION
Selenium's `driver.close()` will forcely close the window, which is different from clicking the close button. So the test case uses `pyautogui` to simulate the clicking of close button. The trick is that the position of close button has to be calculated manually. The test case works on Mac, Linux **Ubuntu 14.04** and Windows 7/8 with **default theme**. For other platforms or themes, it may not work.

And due to #4217, the top offset of the window under Linux is greater than real. So the test case workaround it by subtracting a few pixels from the top coordination to locate the close button.