### PR TITLE
Fix package script for supporting Win XP

### DIFF
--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -199,6 +199,7 @@ def generate_target_nw(platform_name, arch, version):
                            'resources.pak',
                            'nw_100_percent.pak',
                            'nw_200_percent.pak',
+                           'dbghelp.dll'
                            ]
         if flavor == 'sdk':
             target['input'].append('nwjc.exe')


### PR DESCRIPTION
`dbghelp.dll` is required to run on Win XP. Added it to package
script.

Fixed #4181