### PR TITLE
Remove NativeWindowDelegate in cleanup (fixes crash on OS X when closing fullscreen)

### DIFF
--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -186,6 +186,8 @@ enum {
 - (void)cleanup:(id)window {
   if (shell_)
     delete shell_.get();
+  if ([window isKindOfClass:[NSWindow class]])
+    ((NSWindow *)window).delegate = nil;
 
   [self release];
 }


### PR DESCRIPTION
This should fix #3966, where a crash occurs as the delegate is
deallocated while still registered on the window and a resize
notification is sent.

The type check almost definitely isn’t needed, but ¯\_(ツ)_/¯