### PR TITLE
Fix of not finding menubar button when navigate to another menu

### DIFF
--- a/src/browser/menubar_controller.h
+++ b/src/browser/menubar_controller.h
@@ -29,10 +29,14 @@ class MenuBarController : public views::MenuModelAdapter {
       bool* has_mnemonics,
       views::MenuButton** button) override;
 
+  void ExecuteCommand(int id) override;
+  void ExecuteCommand(int id, int mouse_event_flags) override;
+
  private:
   typedef std::map<const ui::MenuModel*, views::MenuItemView*> ModelToMenuMap;
 
   MenuBarView* menubar_;
+  ui::MenuModel* active_menu_model_;
   scoped_ptr<views::MenuRunner> menu_runner_;
   std::vector<MenuBarController*> controllers_;
   static ModelToMenuMap model_to_menu_map_;


### PR DESCRIPTION
When pressing a menubar button and navigate to another, such as
clicking `File` and navigate to `Edit`, `MenuModelAdapter` will
still try to find buttons within the model which it was created
with, which is `File` in this case. The fix is to record current
active model and override two `ExecuteCommand` methods to find
buttons in the correct model.

Fixed #4371