### PR TITLE
Fixed devtools tests failure on CR49

### DIFF
--- a/test/remoting/issue3780-jailed/test.py
+++ b/test/remoting/issue3780-jailed/test.py
@@ -25,7 +25,7 @@ try:
     print 'click Console panel'
     driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
     print 'send_keys "location.pathname<enter>"'
-    driver.switch_to_active_element().send_keys('location.pathname\n')
+    driver.find_element_by_id('console-prompt').send_keys('location.pathname\n')
     pathname = driver.find_element_by_css_selector('.console-user-command-result .console-message-text .object-value-string').get_attribute('textContent')
     print pathname
     assert (pathname == '/child.html')

--- a/test/remoting/issue3835-inspect-crash/test.py
+++ b/test/remoting/issue3835-inspect-crash/test.py
@@ -21,7 +21,7 @@ try:
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
     driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
-    driver.switch_to_active_element().send_keys('chrome\n')
+    driver.find_element_by_id('console-prompt').send_keys('chrome\n')
     driver.find_element_by_class_name('console-object-preview').click()
     time.sleep(1) # wait for crash!
     expanded = driver.find_element_by_css_selector('.console-view-object-properties-section.expanded')


### PR DESCRIPTION
DevTools on CR49 doesn't auto focus on the console input fields, which fails two test cases depends on the behaviour.