### PR TITLE
test case for issue #4171

### DIFF
--- a/test/remoting/issue4171-win-close-event/index.html
+++ b/test/remoting/issue4171-win-close-event/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>win close event</title>
+</head>
+<body>
+  <h1>Try Close</h1>
+  <script>
+  var count = 3;
+  var win = nw.Window.get();
+  win.on('close', function() {
+    if (--count === 0) {
+      win.close(true);
+    } else {
+      out('result-' + count, 'success:' + count);
+    }
+  });
+
+  function out(id, msg) {
+    var h1 = document.createElement('h1');
+    h1.setAttribute('id', id);
+    h1.innerHTML = msg;
+    document.body.appendChild(h1);
+  }
+  </script>
+</body>
+</html>

--- a/test/remoting/issue4171-win-close-event/linux.py
+++ b/test/remoting/issue4171-win-close-event/linux.py
@@ -1,0 +1,26 @@
+from Xlib import display, X, protocol, Xatom
+import time
+
+class WinManager:
+
+    def __init__(self):
+        self.display = display.Display()
+        self.root = self.display.screen().root
+
+    def _create_window(self, wid):
+        return self.display.create_resource_object('window', wid)
+
+    def _get_property(self, atom, win=None):
+        if not win: win = self.root
+        return win.get_full_property(self.display.get_atom(atom), X.AnyPropertyType).value
+
+    def _set_property(self, ctype, data, win):
+        data = (data + [0] * (5 - len(data)))[:5]
+        ev = protocol.event.ClientMessage(window=win, client_type=self.display.get_atom(ctype), data=(32, data))
+        mask = X.SubstructureRedirectMask | X.SubstructureNotifyMask
+        self.root.send_event(ev, event_mask=mask)
+
+    def close_window(self):
+        win = self._create_window(self._get_property('_NET_ACTIVE_WINDOW')[0])
+        self._set_property('_NET_CLOSE_WINDOW', [int(time.mktime(time.localtime())), 1], win)
+        self.display.flush()

--- a/test/remoting/issue4171-win-close-event/mac.py
+++ b/test/remoting/issue4171-win-close-event/mac.py
@@ -1,0 +1,24 @@
+from Foundation import NSAppleScript, NSDictionary
+
+class WinManager:
+
+    def close_window(self):
+        src = '''
+        global frontApp, frontAppName
+
+        tell application "System Events"
+            set frontApp to first application process whose frontmost is true
+            set frontAppName to name of frontApp
+            tell process frontAppName
+                tell (1st window whose value of attribute "AXMain" is true)
+                    click 1st button
+                end tell
+            end tell
+        end tell
+        '''
+
+        s = NSAppleScript.alloc().initWithSource_(src)
+        r, e = s.executeAndReturnError_(None)
+        if e:
+            print e['NSAppleScriptErrorBriefMessage']
+            raise Exception(e['NSAppleScriptErrorBriefMessage'])

--- a/test/remoting/issue4171-win-close-event/package.json
+++ b/test/remoting/issue4171-win-close-event/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue4171-win-close-event",
+  "main": "index.html"
+}

--- a/test/remoting/issue4171-win-close-event/test.py
+++ b/test/remoting/issue4171-win-close-event/test.py
@@ -1,0 +1,45 @@
+import time
+import os
+import platform
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+def click_close():
+    system = platform.system()
+    if system == 'Linux':
+        from linux import WinManager
+        WinManager().close_window()
+    elif system == 'Windows':
+        from win import WinManager
+        WinManager().close_window()
+    elif system == 'Darwin':
+        from mac import WinManager
+        WinManager().close_window()
+    else:
+        print 'Skip for unsupported platform %s' % system
+        return
+    print 'close window'
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options)
+driver.implicitly_wait(5)
+time.sleep(1)
+try:
+    print driver.current_url
+    click_close()
+    result = driver.find_element_by_id('result-2').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+    click_close()
+    result = driver.find_element_by_id('result-1').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+    driver.close()
+finally:
+    driver.quit()

--- a/test/remoting/issue4171-win-close-event/win.py
+++ b/test/remoting/issue4171-win-close-event/win.py
@@ -1,0 +1,7 @@
+import win32gui, win32con
+
+class WinManager:
+
+  def close_window(self):
+    hwnd = win32gui.GetForegroundWindow()
+    win32gui.SendMessage(hwnd, win32con.WM_SYSCOMMAND, win32con.SC_CLOSE, 0)


### PR DESCRIPTION
This test case simulate clicking close button on all platforms. On Windows, it depends on `pywin32`. On Linux, it depends on `python-xlib`. On Mac, it depends on `pyobjc` which was by default installed. In addition, on Mac, you have to enable assistive access for the app that running the test, or you will receive `Python is not allowed assistive access` error. For example, I'm running the tests in `iTerm` app. I need to check `iTerm` app in `System Preferences` -> `Security & Privacy` -> `Accessibility` as below.

![screen shot 2016-03-02 at 13 52 56](https://cloud.githubusercontent.com/assets/471928/13451902/1c5d8a2e-e07e-11e5-976c-9fea074ff5b3.png)
