### PR TITLE
Fix title showing in a frameless window on OSX

### DIFF
--- a/src/browser/native_window_mac.mm
+++ b/src/browser/native_window_mac.mm
@@ -391,7 +391,7 @@ NativeWindowCocoa::NativeWindowCocoa(
   } else {
     shell_window = [[ShellFramelessNSWindow alloc]
         initWithContentRect:cocoa_bounds
-                  styleMask:style_mask
+                  styleMask:0
                     backing:NSBackingStoreBuffered
                       defer:NO];
   }


### PR DESCRIPTION
The mac should not show the title if it's a frameless window. It looked like this before:
http://imgur.com/R4kl83a
The other Window options are also not needed for a frameless window.