### PR TITLE
Typo errors in docs

### DIFF
--- a/docs/For Users/Advanced/JavaScript Contexts in NW.js.md
+++ b/docs/For Users/Advanced/JavaScript Contexts in NW.js.md
@@ -46,7 +46,7 @@ Some objects of Node context are copied to Browser context so that scripts runni
 * `process` -- the [process module](https://nodejs.org/api/globals.html#globals_process) of Node.js; same as `nw.process`
 * `Buffer` -- the [Buffer class](https://nodejs.org/api/globals.html#globals_class_buffer) of Node.js
 
-#### Relative Path Resovling of `require()` in Browser Context
+#### Relative Path Resolving of `require()` in Browser Context
 
 Relative paths in Browser context are resolved according to path of main HTML file (like all browsers do).
 

--- a/docs/For Users/Advanced/Transparent Window.md
+++ b/docs/For Users/Advanced/Transparent Window.md
@@ -23,7 +23,7 @@ In the HTML body, specify the alpha of the background colour:
 <body style="background-color:rgba(0,0,0,0);">
 ```
 
-and specify [`transparent` field](../../References/Manifest Format.md#transparent) to `ture` in manifest:
+and specify [`transparent` field](../../References/Manifest Format.md#transparent) to `true` in manifest:
 ```json
   "window": {
     "transparent": true


### PR DESCRIPTION
Corrected two simple typo errors I discovered in docs