### PR TITLE
Use `innerWidth`/`innerHeight` instead of `outerWidth`/`outerWidth`

### DIFF
--- a/test/remoting/issue4221-win-open-manifest/index.html
+++ b/test/remoting/issue4221-win-open-manifest/index.html
@@ -21,7 +21,7 @@
     window.open('index.html');
   }
   function getwinsize() {
-    out('result', [window.outerWidth, window.outerHeight].join(','));
+    out('result', [window.innerWidth, window.innerHeight].join(','));
   }
   function bindNewWinPolicy() {
     nw.Window.get().on('new-win-policy', function(frame, url, policy) {


### PR DESCRIPTION
Size used in NW.js app is the content (inner) size. Fix for test
case #4221.

Previously it was tested on Linux which wrongly reports the same value of `outerWidth` and `innerWidth` due to upstream issue as #4217.