### PR TITLE
Make menu callback work after navigation

### DIFF
--- a/src/resources/api_nw_menuitem.js
+++ b/src/resources/api_nw_menuitem.js
@@ -8,15 +8,29 @@ var messagingNatives = requireNative('messaging_natives');
 var Event = require('event_bindings').Event;
 var util = nw.require('util');
 var EventEmitter = nw.require('events').EventEmitter;
+var runtimeNatives = requireNative('runtime');
 
-var menuItems = { objs : {}, clickEvent: {} };
-menuItems.clickEvent = new Event("NWObjectclick");
-menuItems.clickEvent.addListener(function(id) {
-  if (!menuItems.objs[id])
-    return;
-  menuItems.objs[id].click();
-  menuItems.objs[id].emit('click');
-});
+var GetExtensionViews = runtimeNatives.GetExtensionViews;
+
+var bgPage = GetExtensionViews(-1, 'BACKGROUND')[0];
+if (typeof bgPage === 'undefined') //new instance window
+  bgPage = window;
+
+if (bgPage === window) {
+
+if (bgPage.__nw_menuitems) {
+  var menuItems = bgPage.__nw_menuitems;
+} else {
+  var menuItems = bgPage.__nw_menuitems = { objs : {}, clickEvent: {} };
+  menuItems.clickEvent = new Event("NWObjectclick");
+  menuItems.clickEvent.addListener(function(id) {
+    var item = menuItems.objs[id];
+    if (!item)
+      return;
+    try{item.click()}catch(e){console.error(e)};
+    try{item.emit('click')}catch(e){console.error(e)};
+  });
+}
 
 function MenuItem(option) {
   if (!(this instanceof MenuItem)) {
@@ -202,3 +216,7 @@ MenuItem.prototype.__defineSetter__('submenu', function(val) {
 });
 
 exports.binding = MenuItem;
+
+} else {
+exports.binding = bgPage.nw.MenuItem;
+}

--- a/test/manual/issue4313-menu-after-nav/index.html
+++ b/test/manual/issue4313-menu-after-nav/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>issue4313-menu-after-nav</title>
+</head>
+<body>
+  <script> 
+  var win = getWindow();
+  win.menu = createMenubar();
+
+  function createMenubar() {
+    var menubar = new nw.Menu({ type: 'menubar' });
+    var itemLoc = new nw.MenuItem({ label: 'Location' });
+    var menuLoc = new nw.Menu();
+
+    menuLoc.append( new nw.MenuItem({ label: 'Click Me', click: function() {win.window.alert('click from index.html')}, modifiers: 'cmd+ctrl', key: 'y' }) );
+    menuLoc.append( new nw.MenuItem({ label: 'To Google.com', click: function() {alert(win.window.location.toString());win.window.location='https://www.google.com/'}, modifiers: 'cmd+ctrl', key: 'g'  }) );
+    menuLoc.append( new nw.MenuItem({ label: 'To next.html', click: function() {alert(win.window.location.toString());win.window.location='next.html'}, modifiers: 'cmd+ctrl', key: 'n'  }) );
+    menuLoc.append( new nw.MenuItem({ label: 'Forward', click: function() {alert(win.window.location.toString());win.window.history.forward()}, modifiers: 'cmd+ctrl', key: 'f'  }) );
+    menuLoc.append( new nw.MenuItem({ label: 'Back', click: function() {alert(win.window.location.toString());win.window.history.back()}, modifiers: 'cmd+ctrl', key: 'b'  }) );
+
+    itemLoc.submenu = menuLoc;
+    menubar.append(itemLoc);
+    return menubar;
+  }
+
+  function getWindow() {
+    return nw.Window.get();
+  }
+  </script>
+</body>
+</html>

--- a/test/manual/issue4313-menu-after-nav/next.html
+++ b/test/manual/issue4313-menu-after-nav/next.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>next</title>
+</head>
+<body>
+  <h1>Next</h1>
+  <button id="goback" onclick="history.back()">Back</button>
+</body>
+</html>

--- a/test/manual/issue4313-menu-after-nav/package.json
+++ b/test/manual/issue4313-menu-after-nav/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue4313-menu-after-nav",
+  "main": "index.html"
+}


### PR DESCRIPTION
Move menus implementation to background page.

This is a partial fix for #4313, which works for navigating to
internal pages.