### PR TITLE
Fixed similar issue of #4579 for `nw.Screen.DesktopCaptureMonitor`

### DIFF
--- a/src/api/nw_screen_api.cc
+++ b/src/api/nw_screen_api.cc
@@ -374,7 +374,7 @@ namespace extensions {
       content::RenderFrameHost* const main_frame = web_contents->GetMainFrame();
       result = registry->RegisterStream(main_frame->GetProcess()->GetID(),
                                         main_frame->GetRoutingID(),
-                                        extension()->url(),
+                                        web_contents->GetURL().GetOrigin(),
                                         source,
                                         extension()->name());
       response->AppendString(result);


### PR DESCRIPTION
NWJS app allows running on origins other than `chrome-extension://*/*`.
The origin should then be from the senders URL, in order not to fail
the origin checking in `DesktopStreamsRegistry::RequestMediaForStreamId`.

See also nwjs/chromium.src#11