### PR TITLE
add web_accessible_resources to manifest of nwjs app

### DIFF
--- a/src/nw_content.cc
+++ b/src/nw_content.cc
@@ -689,6 +689,8 @@ void LoadNWAppAsExtensionHook(base::DictionaryValue* manifest, std::string* erro
     AmendManifestStringList(manifest, manifest_keys::kPermissions, "developerPrivate");
     AmendManifestStringList(manifest, manifest_keys::kPermissions, "management");
     AmendManifestStringList(manifest, manifest_keys::kPermissions, "<all_urls>");
+
+    AmendManifestStringList(manifest, manifest_keys::kWebAccessibleResources, "*");
   }
 
   AmendManifestContentScriptList(manifest, "inject_js_start", "document_start");

--- a/test/remoting/issue4650-history-back/http-server.py
+++ b/test/remoting/issue4650-history-back/http-server.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import SimpleHTTPServer
+import SocketServer
+import sys
+
+PORT = int(sys.argv[1])
+
+Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+
+httpd = SocketServer.TCPServer(("", PORT), Handler)
+
+print "serving at port", PORT
+httpd.serve_forever()
+

--- a/test/remoting/issue4650-history-back/index.tpl
+++ b/test/remoting/issue4650-history-back/index.tpl
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>issue4650-history-back</title>
+</head>
+<body>
+  <h1>index.html</h1>
+  <a id="to-remote" href="http://localhost:{port}/index.html">To remote</a>
+  <a id="history-back" href="###" onclick="history.back()">history.back()</a>
+</body>
+</html>

--- a/test/remoting/issue4650-history-back/package.json
+++ b/test/remoting/issue4650-history-back/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue4650-history-back",
+  "main": "index.html"
+}

--- a/test/remoting/issue4650-history-back/test.py
+++ b/test/remoting/issue4650-history-back/test.py
@@ -1,0 +1,41 @@
+import time
+import os
+import subprocess
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common import utils
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(testdir)
+
+port = str(utils.free_port())
+server = subprocess.Popen(['python', 'http-server.py', port])
+
+fd = open('index.tpl', 'r')
+html = fd.read().replace('{port}', port)
+fd.close()
+
+fd = open('index.html', 'w')
+fd.write(html)
+fd.close()
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])
+driver.implicitly_wait(5)
+time.sleep(1)
+try:
+    print driver.current_url
+    driver.find_element_by_id('to-remote').click()
+    print driver.current_url
+    assert('http://localhost' in driver.current_url)
+    assert('/index.html' in driver.current_url)
+    driver.find_element_by_id('history-back').click()
+    print driver.current_url
+    assert('chrome-extension://' in driver.current_url)
+    assert('/index.html' in driver.current_url)
+finally:
+    server.terminate()
+    driver.quit()


### PR DESCRIPTION
Without `web_accessible_resources`, nwjs app will fail to navigate
from remote pages to chrome extension pages.
See also https://developer.chrome.com/extensions/manifest/web_accessible_resources

Fixed #4650