### PR TITLE
[win] ship with libexif.dll

### DIFF
--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -191,7 +191,9 @@ def generate_target_nw(platform_name, arch, version):
                            'nw_100_percent.pak',
                            'nw_200_percent.pak',
                            'dbghelp.dll',
-                           'ffmpeg.dll'
+                           'ffmpeg.dll',
+                            # To be removed in CR51
+                           'libexif.dll',
                            ]
         if flavor == 'sdk':
             target['input'].append('nwjc.exe')


### PR DESCRIPTION
libexif is loaded on Windows at start up. When loading failed, it
will generate debug.log in the same directory of nw.exe without
`--enable-logging`. Ship `libexif.dll` with NW.js will fix this issue.
On Mac OS X, it's already shipped with NW.js. On Linux, it loads
`libexif.so.12` in system path.

Fixed #4637