### PR TITLE
implemented `win.menu=null` to remove menubar

### DIFF
--- a/docs/For Users/Advanced/Customize Menubar.md
+++ b/docs/For Users/Advanced/Customize Menubar.md
@@ -41,6 +41,9 @@ See both [Menu](../../References/Menu.md) and [Window](../../References/Window.m
 
 On Windows and Linux, the menubars behave exactly the same. Each window can have one menubar and they all reside bellow the titlebar.
 
+!!! tip "Menubar in Fullscreen / Kiosk Mode"
+    In fullscreen or kiosk mode, menubar is visible on top of the window on Windows and Linux. Setting `win.menu` to `null` can completely remove the menubar. See also [`win.menu`](../../References/Window.md#winmenu).
+
 ### Mac OS X
 
 !!! warning "Behavior Changed"

--- a/docs/References/Window.md
+++ b/docs/References/Window.md
@@ -92,7 +92,9 @@ Get or set window's title.
 
 ## win.menu
 
-Get or set window's menubar. Set with a Menu with type `menubar`. See [Menu](Menu.md).
+Get or set window's menubar. Set with a Menu with type `menubar`. When `win.menu` is set to `null`, the menubar is completely removed for Windows and Linux, and the menubar is cleared out on Mac.
+
+See [Customize Menubar](../For Users/Advanced/Customize Menubar.md) for the usage of menubars. And see [Menu](Menu.md) and [MenuItem](MenuItem.md) for detailed APIs.
 
 ## win.isFullscreen
 

--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -314,6 +314,30 @@ NwCurrentWindowInternalClearMenuFunction::~NwCurrentWindowInternalClearMenuFunct
 }
 
 bool NwCurrentWindowInternalClearMenuFunction::RunAsync() {
+  AppWindow* window = getAppWindow(this);
+  if (!window) {
+    error_ = kNoAssociatedAppWindow;
+    return false;
+  }
+
+#if defined(OS_MACOSX)
+  NWChangeAppMenu(NULL);
+#endif
+
+#if defined(OS_LINUX) || defined(OS_WIN)
+  native_app_window::NativeAppWindowViews* native_app_window_views =
+      static_cast<native_app_window::NativeAppWindowViews*>(
+          window->GetBaseWindow());
+
+  BrowserViewLayout *browser_view_layout = static_cast<BrowserViewLayout*>(native_app_window_views->GetLayoutManager());
+  views::View* menubar = browser_view_layout->menu_bar();
+  if (menubar) {
+    native_app_window_views->RemoveChildView(menubar);
+  }
+  browser_view_layout->set_menu_bar(NULL);
+  native_app_window_views->layout_();
+  native_app_window_views->SchedulePaint();
+#endif
   return true;
 }
 

--- a/src/nw_content_mac.mm
+++ b/src/nw_content_mac.mm
@@ -7,7 +7,15 @@
 #import  "ui/gfx/mac/nswindow_frame_controls.h"
 
 void NWChangeAppMenu(nw::Menu* menu) {
-  [NSApp setMainMenu:menu->menu_];
+  NSMenu *main_menu;
+
+  if (menu == nil) {
+    main_menu = [[NSMenu alloc] initWithTitle:@""];
+  } else {
+    main_menu = menu->menu_;
+  }
+  
+  [NSApp setMainMenu:main_menu];
 }
 
 void NWSetNSWindowShowInTaskbar(extensions::NativeAppWindow* win, bool show) {


### PR DESCRIPTION
Previously in 0.12.x the visibility of menubar on fullscreen/kiosk
 mode is inconsistent on different platforms. Since 0.13.0, the
menubar is always visible on fullscreen / kiok mode. Using
`win.menu=null` can remove the menubar manually. This gives
developers better control on the menubars.

This patch implemented `win.menu=null` to completely remove the
menubar on Linux and Windows, and cleared out the menubar on Mac.
The patch also updated the docs about menubar visibility on
fullscreen mode.

Fixed #4725