### PR TITLE
Add `isDevToolsOpen` to public interface

### DIFF
--- a/src/api/nw_current_window_internal.idl
+++ b/src/api/nw_current_window_internal.idl
@@ -17,6 +17,7 @@ namespace nw.currentWindowInternal {
     static void close(optional boolean force);
     static void showDevToolsInternal(optional ShowDevToolsCallback callback);
     static void closeDevTools();
+    static void isDevToolsOpen();
     static void setBadgeLabel(DOMString badge);
     static void requestAttentionInternal(long count);
     static void setProgressBar(double progress);

--- a/src/api/nw_window_api.h
+++ b/src/api/nw_window_api.h
@@ -56,6 +56,18 @@ class NwCurrentWindowInternalCloseDevToolsFunction : public AsyncExtensionFuncti
   DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.closeDevTools", UNKNOWN)
 };
 
+class NwCurrentWindowInternalIsDevToolsOpenFunction : public NWSyncExtensionFunction {
+ public:
+  NwCurrentWindowInternalIsDevToolsOpenFunction() {};
+
+ protected:
+  ~NwCurrentWindowInternalIsDevToolsOpenFunction() override {};
+  bool RunNWSync(base::ListValue* response, std::string* error) override;
+
+  // ExtensionFunction:
+  DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.isDevToolsOpen", UNKNOWN)
+};
+
 class NwCurrentWindowInternalCapturePageInternalFunction : public AsyncExtensionFunction {
  public:
   NwCurrentWindowInternalCapturePageInternalFunction();
@@ -146,7 +158,7 @@ class NwCurrentWindowInternalRequestAttentionInternalFunction : public AsyncExte
  private:
   DISALLOW_COPY_AND_ASSIGN(NwCurrentWindowInternalRequestAttentionInternalFunction);
 };
-  
+
 class NwCurrentWindowInternalSetProgressBarFunction : public AsyncExtensionFunction {
  public:
   NwCurrentWindowInternalSetProgressBarFunction(){}
@@ -245,7 +257,7 @@ class NwCurrentWindowInternalSetShowInTaskbarFunction : public AsyncExtensionFun
 
  protected:
   ~NwCurrentWindowInternalSetShowInTaskbarFunction() override {}
-  
+
    // ExtensionFunction:
    bool RunAsync() override;
    DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.setShowInTaskbar", UNKNOWN)


### PR DESCRIPTION
`isDevToolsOpen` is not present on a `Window` object since at least 0.13 (see, eg., #4487).

This patch adds `isDevToolsOpen` to a few places where it is missing.

You can test presence (or thereof) with a simple app:

~~~
<script>
  alert(nw.Window.get().showDevTools); // function...
  alert(nw.Window.get().isDevToolsOpen); // undefined
</script>
~~~

Issue was first encountered while testing on `0.14.0-sdk-1` from npm after upgrading from `^0.12`.