### PR TITLE
Extended `nw.Clipboard` to support multiple data types

### DIFF
--- a/docs/References/Clipboard.md
+++ b/docs/References/Clipboard.md
@@ -30,19 +30,35 @@ clipboard.clear();
 !!! note
     The Selection Clipboard in X11 is not supported.
 
-## clip.set(data, [type])
+## clip.set(data, [type, [raw]])
 
 * `data` `{String}` the data to write to the clipboard
-* `type` `{String}` _Optional_ the type of the data. Currently only `"text"` (plain text) is support. By default, `type` is set to `"text"`.
+* `type` `{String}` _Optional_ the type of the data. Support `text`, `png`, `jpeg`, `html` and `rtf`. By default, `type` is set to `"text"`.
+* `raw`  `{Boolean}` _Optional_ requiring raw image data. This option is only valid if type is `png` or `jpeg`. By default, `raw` is set to `false`.
 
 Write `data` of `type` to the clipboard.
 
+!!! tip "Format of Image"
+    Images read or written from clipboard can be either JPEG or PNG. When `raw` is not set or set to `false`, the data is expected to be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs) encoded with Base64. When `raw` is set to `true`, the data is only the Base64 encoded image data not including the `data:<mime-type>;base64,` part.
+
 ## clip.get([type])
 
-* `type` `{String}` _Optional_ the type of the data. Currently only `"text"` (plain text) is support. By default, `type` is set to `"text"`.
+* `type` `{String}` _Optional_ the type of the data. Support `text`, `png`, `jpeg`, `html` and `rtf`. By default, `type` is set to `"text"`.
+* `raw`  `{Boolean}` _Optional_ requiring raw image data. This option is only valid if type is `png` or `jpeg`.
 * Returns `{String}` the data retrieved from the clipboard
 
 Get the data of `type` from clipboard.
+
+## clip.readAvailableTypes()
+
+* Returns `{Array}` list of available types of data in clipboard currenly. Each item is one of following types:
+    - `text`: plain text. Can be read by `clip.get('text')`.
+    - `html`: HTML text. Can be read by `clip.get('html')`.
+    - `rtf`: RTF (Rich Text Format). Can be read by `clip.get('rtf')`.
+    - `png`: PNG image. Can be read by `clip.get('png')`.
+    - `jpeg`: JPEG image. Can be read by `clip.get('jpeg')`.
+
+You can use the returned list as a suggestion to get the right data from clipboard.
 
 ## clip.clear()
 

--- a/src/api/nw_clipboard.idl
+++ b/src/api/nw_clipboard.idl
@@ -5,14 +5,19 @@
 // nw Clipboard API
 [implemented_in="content/nw/src/api/nw_clipboard_api.h"]
 namespace nw.Clipboard {
-  [noinline_doc] dictionary NWClipboard {
-    static DOMString get(DOMString type);
-    static void set(DOMString content, DOMString type);
+
+  [noinline_doc] enum Type {
+    text,
+    png,
+    jpeg,
+    html,
+    rtf
   };
+
   interface Functions {
-    [nocompile] static NWClipboard get();
-    static DOMString getSync(DOMString type);
-    static void setSync(DOMString content, DOMString type);
+    static DOMString getSync(Type type, boolean raw);
+    static void setSync(DOMString content, Type type, boolean raw);
     static void clearSync();
+    static DOMString[] readAvailableTypes();
   };
 };

--- a/src/api/nw_clipboard_api.cc
+++ b/src/api/nw_clipboard_api.cc
@@ -1,15 +1,33 @@
 #include "content/nw/src/api/nw_clipboard_api.h"
 
+#include "base/base64.h"
+#include "base/logging.h"
+#include "base/strings/stringprintf.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/devtools/devtools_window.h"
 #include "chrome/browser/extensions/devtools_util.h"
 #include "chrome/browser/extensions/extension_service.h"
+#include "content/nw/src/api/nw_clipboard.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/web_contents.h"
 #include "extensions/browser/extension_system.h"
 #include "extensions/common/error_utils.h"
 #include "ui/base/clipboard/clipboard.h"
+#include "ui/base/clipboard/scoped_clipboard_writer.h"
+#include "ui/gfx/codec/jpeg_codec.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+
+using namespace extensions::nwapi::nw__clipboard;
 
 namespace extensions {
+
+namespace {
+  const char* kPNGDataUriPrefix = "data:image/png;base64,";
+  const char* kJPEGDataUriPrefix = "data:image/jpeg;base64,";
+  const int   kQulity = 100;
+}
 
 NwClipboardGetSyncFunction::NwClipboardGetSyncFunction() {
 }
@@ -18,13 +36,77 @@ NwClipboardGetSyncFunction::~NwClipboardGetSyncFunction() {
 }
 
 bool NwClipboardGetSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
-
+  scoped_ptr<GetSync::Params> params(GetSync::Params::Create(*args_));
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
-  base::string16 text;
-  clipboard->ReadText(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
-  response->Append(new base::StringValue(text));
-  LOG(INFO) << "NwClipboardGetSyncFunction::RunSync: " << text;
-  return true;
+
+  if (params->type == TYPE_TEXT) {
+    base::string16 text;
+    clipboard->ReadText(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
+    response->Append(new base::StringValue(text));
+    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(text)";
+    return true;
+  } else if (params->type == TYPE_PNG || params->type == TYPE_JPEG) {
+    std::vector<unsigned char> encoded_image;
+    SkBitmap bitmap = clipboard->ReadImage(ui::CLIPBOARD_TYPE_COPY_PASTE);
+    SkAutoLockPixels lock(bitmap);
+
+    if (bitmap.isNull()) {
+      response->Append(new base::StringValue(""));
+      return true;
+    }
+
+    if (params->type == TYPE_PNG &&
+       !gfx::PNGCodec::EncodeA8SkBitmap(bitmap, &encoded_image)) {
+      LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ") failed when converting to PNG";
+      *error = "Failed to encode as PNG";
+      return false;
+    } else if (params->type == TYPE_JPEG &&
+               !gfx::JPEGCodec::Encode(reinterpret_cast<const unsigned char*>(bitmap.getPixels()),
+                                      gfx::JPEGCodec::FORMAT_SkBitmap,
+                                      bitmap.width(),
+                                      bitmap.height(),
+                                      bitmap.rowBytes(),
+                                      kQulity,
+                                      &encoded_image)) {
+      LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ") failed when converting to JPEG";
+      *error = "Failed to encode as JPEG";
+      return false;
+    }
+
+    std::string encoded_image_base64;
+    std::string encoded_image_str(encoded_image.data(), encoded_image.data() + encoded_image.size());
+    base::Base64Encode(encoded_image_str, &encoded_image_base64);
+
+    if (!params->raw) {
+      if (params->type == TYPE_PNG) {
+        encoded_image_base64.insert(0, kPNGDataUriPrefix);
+      } else if (params->type == TYPE_JPEG) {
+        encoded_image_base64.insert(0, kJPEGDataUriPrefix);
+      }
+    }
+
+    response->Append(new base::StringValue(encoded_image_base64));
+    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ")";
+    return true;
+  } else if (params->type == TYPE_HTML) {
+    base::string16 text;
+    std::string src_url;
+    uint32_t fragment_start, fragment_end;
+    clipboard->ReadHTML(ui::CLIPBOARD_TYPE_COPY_PASTE, &text, &src_url, &fragment_start, &fragment_end);
+    response->Append(new base::StringValue(text));
+    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(html)";
+    return true;
+  } else if (params->type == TYPE_RTF) {
+    std::string text;
+    clipboard->ReadRTF(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
+    response->Append(new base::StringValue(text));
+    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(rtf)";
+    return true;
+  } else {
+    NOTREACHED();
+    return false;
+  }
+ 
 }
 
 NwClipboardSetSyncFunction::NwClipboardSetSyncFunction() {
@@ -36,14 +118,56 @@ NwClipboardSetSyncFunction::~NwClipboardSetSyncFunction() {
 
 
 bool NwClipboardSetSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
-  std::string text;
-  args_->GetString(0, &text);
+  scoped_ptr<SetSync::Params> params(SetSync::Params::Create(*args_));
+  ui::ScopedClipboardWriter scw(ui::CLIPBOARD_TYPE_COPY_PASTE);
 
-  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
-  ui::Clipboard::ObjectMap map;
-  map[ui::Clipboard::CBF_TEXT].push_back(
-      std::vector<char>(text.begin(), text.end()));
-  clipboard->WriteObjects(ui::CLIPBOARD_TYPE_COPY_PASTE, map);
+  if (params->type == TYPE_TEXT) {
+    scw.WriteText(base::UTF8ToUTF16(params->content));
+  } else if (params->type == TYPE_PNG || params->type == TYPE_JPEG) {
+
+    std::string content = params->content;
+
+    // strip off data uri header if raw is set
+    if (!params->raw) {
+      if (params->type == TYPE_PNG && base::StartsWith(content, kPNGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
+          content = content.substr(strlen(kPNGDataUriPrefix));
+      } else if (params->type == TYPE_JPEG && base::StartsWith(content, kJPEGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
+          content = content.substr(strlen(kJPEGDataUriPrefix));
+      } else {
+        *error = base::StringPrintf("Invalid data URI. Only \"%s\" or \"%s\" is accepted.", kPNGDataUriPrefix, kJPEGDataUriPrefix);
+        return false;
+      }
+    }
+
+    std::string decoded_str;
+    if (!base::Base64Decode(content, &decoded_str)) {
+      *error = "Bad base64 string";
+      return false;
+    }
+
+    scoped_ptr<SkBitmap> bitmap(new SkBitmap());
+    if (params->type == TYPE_PNG &&
+      !gfx::PNGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size(), bitmap.get())) {
+      *error = "Failed to decode as PNG";
+      return false;
+    } else if (params->type == TYPE_JPEG) {
+      SkBitmap* tmp_bitmap = gfx::JPEGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size());
+      if (tmp_bitmap == NULL) {
+        *error = "Failed to decode as JPEG";
+        return false;
+      }
+      bitmap.reset(tmp_bitmap);
+    }
+
+    scw.WriteImage(*bitmap);
+  } else if (params->type == TYPE_HTML) {
+    scw.WriteHTML(base::UTF8ToUTF16(params->content), std::string());
+  } else if (params->type == TYPE_RTF) {
+    scw.WriteRTF(params->content);
+  } else {
+    NOTREACHED();
+    return false;
+  }
 
   return true;
 }
@@ -59,6 +183,34 @@ NwClipboardClearSyncFunction::~NwClipboardClearSyncFunction() {
 bool NwClipboardClearSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   clipboard->Clear(ui::CLIPBOARD_TYPE_COPY_PASTE);
+  return true;
+}
+
+NwClipboardReadAvailableTypesFunction::NwClipboardReadAvailableTypesFunction() {
+
+}
+
+NwClipboardReadAvailableTypesFunction::~NwClipboardReadAvailableTypesFunction() {
+
+}
+
+bool NwClipboardReadAvailableTypesFunction::RunNWSync(base::ListValue* response, std::string* error) {
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  bool contains_filenames;
+  std::vector<base::string16> types;
+  clipboard->ReadAvailableTypes(ui::CLIPBOARD_TYPE_COPY_PASTE, &types, &contains_filenames);
+  for(std::vector<base::string16>::iterator it = types.begin(); it != types.end(); it++) {
+    if (base::EqualsASCII(*it, ui::Clipboard::kMimeTypeText)) {
+      response->Append(new base::StringValue(ToString(TYPE_TEXT)));
+    } else if (base::EqualsASCII(*it, ui::Clipboard::kMimeTypeHTML)) {
+      response->Append(new base::StringValue(ToString(TYPE_HTML)));
+    } else if (base::EqualsASCII(*it, ui::Clipboard::kMimeTypeRTF)) {
+      response->Append(new base::StringValue(ToString(TYPE_RTF)));
+    } else if (base::EqualsASCII(*it, ui::Clipboard::kMimeTypePNG)) {
+      response->Append(new base::StringValue(ToString(TYPE_PNG)));
+      response->Append(new base::StringValue(ToString(TYPE_JPEG)));
+    }
+  }
   return true;
 }
 

--- a/src/api/nw_clipboard_api.h
+++ b/src/api/nw_clipboard_api.h
@@ -47,5 +47,19 @@ class NwClipboardClearSyncFunction : public NWSyncExtensionFunction {
   DISALLOW_COPY_AND_ASSIGN(NwClipboardClearSyncFunction);
 };
 
+class NwClipboardReadAvailableTypesFunction : public NWSyncExtensionFunction {
+ public:
+  NwClipboardReadAvailableTypesFunction();
+  bool RunNWSync(base::ListValue* response, std::string* error) override;
+
+ protected:
+  ~NwClipboardReadAvailableTypesFunction() override;
+
+  DECLARE_EXTENSION_FUNCTION("nw.Clipboard.readAvailableTypes", UNKNOWN)
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NwClipboardReadAvailableTypesFunction);
+};
+
+
 } // namespace extensions
 #endif

--- a/src/resources/api_nw_clipboard.js
+++ b/src/resources/api_nw_clipboard.js
@@ -11,6 +11,12 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
       return sendRequest.sendRequestSync(this.name, arguments, this.definition.parameters, {})[0];
     });
   });
+
+  ['readAvailableTypes'].forEach(function(nwSyncAPIName) {
+    apiFunctions.setHandleRequest(nwSyncAPIName, function() {
+      return sendRequest.sendRequestSync(this.name, arguments, this.definition.parameters, {});
+    });
+  });
 });
 
 var nwClipboardBinding = nw_binding.generate();
@@ -28,14 +34,17 @@ NWClipboard.get = function() {
   return clipboard;
 };
 
-NWClipboard.prototype.get = function (type) {
-  return nwClipboardBinding.getSync(type || 'text');
+NWClipboard.prototype.get = function (type, raw) {
+  return nwClipboardBinding.getSync(type || 'text', !!raw);
 };
-NWClipboard.prototype.set = function (content, type) {
-  return nwClipboardBinding.setSync(content, type || 'text');
+NWClipboard.prototype.set = function (content, type, raw) {
+  return nwClipboardBinding.setSync(content, type || 'text', !!raw);
 };
 NWClipboard.prototype.clear = function () {
   return nwClipboardBinding.clearSync();
+};
+NWClipboard.prototype.readAvailableTypes = function() {
+  return nwClipboardBinding.readAvailableTypes();
 };
 
 exports.binding = NWClipboard;


### PR DESCRIPTION
Following types are supported:

* Text
* HTML
* RTF (Rich Text Format)
* image of PNG and JPEG

Fixed #2677