### PR TITLE
Added `isDevToolsOpen` interface and missing impl.

### DIFF
--- a/src/api/nw_current_window_internal.idl
+++ b/src/api/nw_current_window_internal.idl
@@ -17,6 +17,7 @@ namespace nw.currentWindowInternal {
     static void close(optional boolean force);
     static void showDevToolsInternal(optional ShowDevToolsCallback callback);
     static void closeDevTools();
+    static void isDevToolsOpen();
     static void setBadgeLabel(DOMString badge);
     static void requestAttentionInternal(long count);
     static void setProgressBar(double progress);

--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -169,6 +169,20 @@ bool NwCurrentWindowInternalCloseDevToolsFunction::RunAsync() {
   return true;
 }
 
+bool NwCurrentWindowInternalIsDevToolsOpenFunction::RunNWSync(base::ListValue* response, std::string* error) {
+  content::RenderFrameHost* rfh = render_frame_host();
+  content::WebContents* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+  scoped_refptr<content::DevToolsAgentHost> agent(
+      content::DevToolsAgentHost::GetOrCreateFor(web_contents));
+  DevToolsWindow* devtools_window =
+      DevToolsWindow::FindDevToolsWindow(agent.get());
+  if (devtools_window)
+    response->AppendBoolean(true);
+  else
+    response->AppendBoolean(false);
+  return true;
+}
+
 NwCurrentWindowInternalCapturePageInternalFunction::NwCurrentWindowInternalCapturePageInternalFunction() {
 }
 

--- a/src/api/nw_window_api.h
+++ b/src/api/nw_window_api.h
@@ -56,6 +56,18 @@ class NwCurrentWindowInternalCloseDevToolsFunction : public AsyncExtensionFuncti
   DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.closeDevTools", UNKNOWN)
 };
 
+class NwCurrentWindowInternalIsDevToolsOpenFunction : public NWSyncExtensionFunction {
+ public:
+  NwCurrentWindowInternalIsDevToolsOpenFunction() {};
+
+ protected:
+  ~NwCurrentWindowInternalIsDevToolsOpenFunction() override {};
+  bool RunNWSync(base::ListValue* response, std::string* error) override;
+
+  // ExtensionFunction:
+  DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.isDevToolsOpen", UNKNOWN)
+};
+
 class NwCurrentWindowInternalCapturePageInternalFunction : public AsyncExtensionFunction {
  public:
   NwCurrentWindowInternalCapturePageInternalFunction();

--- a/src/api/window/window.cc
+++ b/src/api/window/window.cc
@@ -327,7 +327,7 @@ void Window::CallSync(const std::string& method,
     bool transparent = shell_->window()->IsTransparent();
     result->AppendBoolean(transparent);
   } else if (method == "IsDevToolsOpen") {
-    result->AppendBoolean(shell_->devToolsOpen());
+    result->AppendBoolean(shell_->IsDevToolsOpen());
   } else if (method == "ShowDevTools") {
     std::string jail_id;
     bool headless = false;

--- a/src/api/window_bindings.js
+++ b/src/api/window_bindings.js
@@ -241,10 +241,10 @@ Window.prototype.__defineSetter__('isFullscreen', function(flag) {
     this.leaveFullscreen();
 });
 
-Window.prototype.isDevToolsOpen = function () {
+Window.prototype.__defineGetter__('isDevToolsOpen' = function () {
     var result = CallObjectMethodSync(this, 'IsDevToolsOpen', []);
     return Boolean(result[0]);
-}
+});
 
 Window.prototype.__defineGetter__('isFullscreen', function() {
   var result = CallObjectMethodSync(this, 'IsFullscreen', []);

--- a/src/nw_shell.h
+++ b/src/nw_shell.h
@@ -111,7 +111,7 @@ class Shell : public WebContentsDelegate,
   void ReloadOrStop();
   void ShowDevTools(const char* jail_id = NULL, bool headless = false);
   void CloseDevTools();
-  bool devToolsOpen() { return devtools_window_.get() != NULL; }
+  bool IsDevToolsOpen() { return devtools_window_.get() != NULL; }
   // Send an event to renderer.
   void SendEvent(const std::string& event, const std::string& arg1 = "");
   void SendEvent(const std::string& event, const base::ListValue& args);


### PR DESCRIPTION
[Follow up from #4751]

`isDevToolsOpen` is not present on a Window object since at least 0.13 (see, eg., #4487).

This patch 
- adds `isDevToolsOpen` interface where it was missing;
- adds a concrete implementation;
- fixes a few consistency issues.

You can test presence (or thereof) with a simple app:

```
<script>
  alert(nw.Window.get().showDevTools); // function...
  alert(nw.Window.get().isDevToolsOpen); // undefined
</script>
```

Issue was first encountered while testing on 0.14.0-sdk-1 from npm after upgrading from ^0.12.
