### PR TITLE
not display errors if menuitem don't have `click` property

### DIFF
--- a/src/resources/api_nw_menuitem.js
+++ b/src/resources/api_nw_menuitem.js
@@ -12,10 +12,11 @@ var EventEmitter = nw.require('events').EventEmitter;
 var menuItems = { objs : {}, clickEvent: {} };
 menuItems.clickEvent = new Event("NWObjectclick");
 menuItems.clickEvent.addListener(function(id) {
-  if (!menuItems.objs[id])
+  var obj = menuItems.objs[id];
+  if (!obj)
     return;
-  menuItems.objs[id].click();
-  menuItems.objs[id].emit('click');
+  try{obj.click && obj.click()}catch(e){console.error(e)}
+  try{obj.emit('click')}catch(e){console.error(e)}
 });
 
 function MenuItem(option) {


### PR DESCRIPTION
`click` property is documented as optional. It should not be an
error if `click` doesn't exist.

fixed #4862