### PR TITLE
added new APIs for read/write multiple types of data to clipboard

### DIFF
--- a/docs/References/Clipboard.md
+++ b/docs/References/Clipboard.md
@@ -36,18 +36,59 @@ clipboard.clear();
 * `type` `{String}` _Optional_ the type of the data. Support `text`, `png`, `jpeg`, `html` and `rtf`. By default, `type` is set to `"text"`.
 * `raw`  `{Boolean}` _Optional_ requiring raw image data. This option is only valid if type is `png` or `jpeg`. By default, `raw` is set to `false`.
 
-Write `data` of `type` to the clipboard.
+Write `data` of `type` to the clipboard. This method will clear the clipboard and replace with the given `data`. Hence another call to this method will overwrite with the new one. To write multiple types of data to clipboard simultaneously, you will need to use [clip.set(clipboardDataList)](clipsetclipboardDataList) below.
 
 !!! tip "Format of Image"
     Images read or written from clipboard can be either JPEG or PNG. When `raw` is not set or set to `false`, the data is expected to be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs) encoded with Base64. When `raw` is set to `true`, the data is only the Base64 encoded image data not including the `data:<mime-type>;base64,` part.
 
-## clip.get([type])
+## clip.set(clipboardData)
+
+* `clipboardData` `{Object}` JSON object containing `data`, `type` and `raw` to be written to clipboard. See [clip.set(data, [type, [raw]])](#clipsetdata-type-raw) for detailed arguments specification.
+
+## clip.set(clipboardDataList)
+
+* `clipboardDataList` `{Array}` Array of `clipboardData` to be written to clipboard. See [clip.set(clipboardData)](#clipsetclipboardData) and [clip.set(data, [type, [raw]])](#clipsetdata-type-raw) for detailed arguments specification.
+
+Multiple types of data can be written to clipboard simultaneously with this method.
+
+Example: write an image and a `<img>` pointing to the image to the clipboard
+
+```javascript
+var fs = require('fs');
+var path = require('path');
+
+// resolve path as absolute path in order to be used by other applications
+var pngPath = path.resolve('nw.png');
+// read the image from file system as base64 encoded string
+var data = fs.readFileSync(pngPath).toString('base64');
+// transform file path to URL
+var html = '<img src="file:///' + encodeURI(data.replace(/^\//, '')) + '">';
+
+var clip = nw.Clipboard.get();
+// write both PNG and HTML to clipboard
+clip.set([
+  {type: 'png', data: data, raw: true},
+  {type: 'html', data: html}
+]);
+```
+
+## clip.get([type, [raw]])
 
 * `type` `{String}` _Optional_ the type of the data. Support `text`, `png`, `jpeg`, `html` and `rtf`. By default, `type` is set to `"text"`.
 * `raw`  `{Boolean}` _Optional_ requiring raw image data. This option is only valid if type is `png` or `jpeg`.
 * Returns `{String}` the data retrieved from the clipboard
 
 Get the data of `type` from clipboard.
+
+## clip.get(clipboardData)
+
+* `clipboardData` `{Object}` JSON object containing `type` and `raw` argument for reading data from clipboard. See [clip.get([type, [raw]])](#clipgettype-raw) for detailed arguments specification.
+* Returns `{String}` the data retrieved from the clipboard
+
+## clip.get(clipboardDataList)
+
+* `clipboardDataList` `{Array}` Array of `clipboardData` for reading data from clipboard. Multiple types of data can be read from clipboard simultaneously with this method. See [clip.get(clipboardData)](#clipgetclipboardData) and [clip.get([type, [raw]])](#clipgettype-raw) for detailed arguments specification.
+* Returns `{Array}` array of `clipboardData` retrieved from the clipboard. Each item contains `type`, `data` and `raw` (optional) attributes.
 
 ## clip.readAvailableTypes()
 

--- a/src/api/nw_clipboard.idl
+++ b/src/api/nw_clipboard.idl
@@ -14,9 +14,15 @@ namespace nw.Clipboard {
     rtf
   };
 
+  dictionary ClipboardData {
+    Type type;
+    boolean? raw;
+    DOMString? data;
+  };
+
   interface Functions {
-    static DOMString getSync(Type type, boolean raw);
-    static void setSync(DOMString content, Type type, boolean raw);
+    static ClipboardData[] getListSync(ClipboardData[] data);
+    static void setListSync(ClipboardData[] data);
     static void clearSync();
     static DOMString[] readAvailableTypes();
   };

--- a/src/api/nw_clipboard_api.cc
+++ b/src/api/nw_clipboard_api.cc
@@ -27,146 +27,262 @@ namespace {
   const char* kPNGDataUriPrefix = "data:image/png;base64,";
   const char* kJPEGDataUriPrefix = "data:image/jpeg;base64,";
   const int   kQulity = 100;
-}
 
-NwClipboardGetSyncFunction::NwClipboardGetSyncFunction() {
-}
+  class ClipboardReader {
+  public:
+    ClipboardReader() {
+      clipboard_ = ui::Clipboard::GetForCurrentThread();
+    }
 
-NwClipboardGetSyncFunction::~NwClipboardGetSyncFunction() {
-}
+    bool Read(ClipboardData& data) {
+      switch(data.type) {
+        case TYPE_TEXT:
+        return ReadText(data);
+        break;
+        case TYPE_HTML:
+        return ReadHTML(data);
+        break;
+        case TYPE_RTF:
+        return ReadRTF(data);
+        break;
+        case TYPE_PNG:
+        case TYPE_JPEG:
+        return ReadImage(data);
+        break;
+        case TYPE_NONE:
+        NOTREACHED();
+        return false;
+      }
+      NOTREACHED();
+      return false;      
+    }
 
-bool NwClipboardGetSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
-  scoped_ptr<GetSync::Params> params(GetSync::Params::Create(*args_));
-  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+    std::string error() {
+      return error_;
+    }
 
-  if (params->type == TYPE_TEXT) {
-    base::string16 text;
-    clipboard->ReadText(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
-    response->Append(new base::StringValue(text));
-    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(text)";
-    return true;
-  } else if (params->type == TYPE_PNG || params->type == TYPE_JPEG) {
-    std::vector<unsigned char> encoded_image;
-    SkBitmap bitmap = clipboard->ReadImage(ui::CLIPBOARD_TYPE_COPY_PASTE);
-    SkAutoLockPixels lock(bitmap);
-
-    if (bitmap.isNull()) {
-      response->Append(new base::StringValue(""));
+  private:
+    bool ReadText(ClipboardData& data) {
+      DCHECK(data.type == TYPE_TEXT);
+      base::string16 text;
+      clipboard_->ReadText(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
+      data.data.reset(new std::string(base::UTF16ToUTF8(text)));
       return true;
     }
 
-    if (params->type == TYPE_PNG &&
-       !gfx::PNGCodec::EncodeA8SkBitmap(bitmap, &encoded_image)) {
-      LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ") failed when converting to PNG";
-      *error = "Failed to encode as PNG";
-      return false;
-    } else if (params->type == TYPE_JPEG &&
-               !gfx::JPEGCodec::Encode(reinterpret_cast<const unsigned char*>(bitmap.getPixels()),
-                                      gfx::JPEGCodec::FORMAT_SkBitmap,
-                                      bitmap.width(),
-                                      bitmap.height(),
-                                      bitmap.rowBytes(),
-                                      kQulity,
-                                      &encoded_image)) {
-      LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ") failed when converting to JPEG";
-      *error = "Failed to encode as JPEG";
-      return false;
+    bool ReadHTML(ClipboardData& data) {
+      DCHECK(data.type == TYPE_HTML);
+      base::string16 text;
+      std::string src_url;
+      uint32_t fragment_start, fragment_end;
+      clipboard_->ReadHTML(ui::CLIPBOARD_TYPE_COPY_PASTE, &text, &src_url, &fragment_start, &fragment_end);
+      data.data.reset(new std::string(base::UTF16ToUTF8(text)));
+      return true;
     }
 
-    std::string encoded_image_base64;
-    std::string encoded_image_str(encoded_image.data(), encoded_image.data() + encoded_image.size());
-    base::Base64Encode(encoded_image_str, &encoded_image_base64);
+    bool ReadRTF(ClipboardData& data) {
+      DCHECK(data.type == TYPE_RTF);
+      std::string text;
+      clipboard_->ReadRTF(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
+      data.data.reset(new std::string(text));
+      return true;
+    }
 
-    if (!params->raw) {
-      if (params->type == TYPE_PNG) {
-        encoded_image_base64.insert(0, kPNGDataUriPrefix);
-      } else if (params->type == TYPE_JPEG) {
-        encoded_image_base64.insert(0, kJPEGDataUriPrefix);
+    bool ReadImage(ClipboardData& data) {
+      DCHECK(data.type == TYPE_PNG || data.type == TYPE_JPEG);
+      std::vector<unsigned char> encoded_image;
+      SkBitmap bitmap = clipboard_->ReadImage(ui::CLIPBOARD_TYPE_COPY_PASTE);
+      SkAutoLockPixels lock(bitmap);
+
+      if (bitmap.isNull()) {
+        return true;
       }
+
+      if (data.type == TYPE_PNG &&
+         !gfx::PNGCodec::EncodeA8SkBitmap(bitmap, &encoded_image)) {
+        LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(data.type) << ") failed when converting to PNG";
+        error_ = "Failed to encode as PNG";
+        return false;
+      } else if (data.type == TYPE_JPEG &&
+                 !gfx::JPEGCodec::Encode(reinterpret_cast<const unsigned char*>(bitmap.getPixels()),
+                                        gfx::JPEGCodec::FORMAT_SkBitmap,
+                                        bitmap.width(),
+                                        bitmap.height(),
+                                        bitmap.rowBytes(),
+                                        kQulity,
+                                        &encoded_image)) {
+        LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(data.type) << ") failed when converting to JPEG";
+        error_ = "Failed to encode as JPEG";
+        return false;
+      }
+
+      std::string encoded_image_base64;
+      std::string encoded_image_str(encoded_image.data(), encoded_image.data() + encoded_image.size());
+      base::Base64Encode(encoded_image_str, &encoded_image_base64);
+
+      if (!*(data.raw)) {
+        if (data.type == TYPE_PNG) {
+          encoded_image_base64.insert(0, kPNGDataUriPrefix);
+        } else {
+          DCHECK(data.type == TYPE_JPEG);
+          encoded_image_base64.insert(0, kJPEGDataUriPrefix);
+        }
+      }
+
+      data.data.reset(new std::string(encoded_image_base64));
+      LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(data.type) << ")";
+      return true;
     }
 
-    response->Append(new base::StringValue(encoded_image_base64));
-    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(" << nwapi::nw__clipboard::ToString(params->type) << ")";
-    return true;
-  } else if (params->type == TYPE_HTML) {
-    base::string16 text;
-    std::string src_url;
-    uint32_t fragment_start, fragment_end;
-    clipboard->ReadHTML(ui::CLIPBOARD_TYPE_COPY_PASTE, &text, &src_url, &fragment_start, &fragment_end);
-    response->Append(new base::StringValue(text));
-    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(html)";
-    return true;
-  } else if (params->type == TYPE_RTF) {
-    std::string text;
-    clipboard->ReadRTF(ui::CLIPBOARD_TYPE_COPY_PASTE, &text);
-    response->Append(new base::StringValue(text));
-    LOG(INFO) << "NwClipboardGetSyncFunction::RunSync(rtf)";
-    return true;
-  } else {
-    NOTREACHED();
-    return false;
-  }
- 
-}
+    ui::Clipboard* clipboard_;
+    std::string error_;
+  };
 
-NwClipboardSetSyncFunction::NwClipboardSetSyncFunction() {
+  class ClipboardWriter {
+  public:
+    ClipboardWriter() {
+      scw_.reset(new ui::ScopedClipboardWriter(ui::CLIPBOARD_TYPE_COPY_PASTE));
+    }
 
-}
+    ~ClipboardWriter() {
+      scw_.reset();
+    }
 
-NwClipboardSetSyncFunction::~NwClipboardSetSyncFunction() {
-}
+    bool Write(ClipboardData& data) {
+      switch(data.type) {
+        case TYPE_TEXT:
+        return WriteText(data);
+        break;
+        case TYPE_HTML:
+        return WriteHTML(data);
+        break;
+        case TYPE_RTF:
+        return WriteRTF(data);
+        break;
+        case TYPE_PNG:
+        case TYPE_JPEG:
+        return WriteImage(data);
+        break;
+        case TYPE_NONE:
+        NOTREACHED();
+        return false;
+      }
+      NOTREACHED();
+      return false;
+    }
 
+    std::string error() const {
+      return error_;
+    }
 
-bool NwClipboardSetSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
-  scoped_ptr<SetSync::Params> params(SetSync::Params::Create(*args_));
-  ui::ScopedClipboardWriter scw(ui::CLIPBOARD_TYPE_COPY_PASTE);
+    void Reset() {
+      scw_->Reset();
+    }
 
-  if (params->type == TYPE_TEXT) {
-    scw.WriteText(base::UTF8ToUTF16(params->content));
-  } else if (params->type == TYPE_PNG || params->type == TYPE_JPEG) {
+  private:
+    bool WriteText(ClipboardData& data) {
+      DCHECK(data.type == TYPE_TEXT);
+      scw_->WriteText(base::UTF8ToUTF16(*(data.data)));
+      return true;
+    }
 
-    std::string content = params->content;
+    bool WriteHTML(ClipboardData& data) {
+      DCHECK(data.type == TYPE_HTML);
+      scw_->WriteHTML(base::UTF8ToUTF16(*(data.data)), std::string());
+      return true;
+    }
 
-    // strip off data uri header if raw is set
-    if (!params->raw) {
-      if (params->type == TYPE_PNG && base::StartsWith(content, kPNGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
+    bool WriteRTF(ClipboardData& data) {
+      DCHECK(data.type == TYPE_RTF);
+      scw_->WriteRTF(*(data.data));
+      return true;
+    }
+
+    bool WriteImage(ClipboardData& data) {
+      DCHECK(data.type == TYPE_PNG || data.type == TYPE_JPEG);
+      std::string content = *(data.data);
+
+      // strip off data uri header if raw is set
+      if (!*(data.raw)) {
+        if (data.type == TYPE_PNG && base::StartsWith(content, kPNGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
           content = content.substr(strlen(kPNGDataUriPrefix));
-      } else if (params->type == TYPE_JPEG && base::StartsWith(content, kJPEGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
+        } else if (data.type == TYPE_JPEG && base::StartsWith(content, kJPEGDataUriPrefix, base::CompareCase::INSENSITIVE_ASCII)) {
           content = content.substr(strlen(kJPEGDataUriPrefix));
-      } else {
-        *error = base::StringPrintf("Invalid data URI. Only \"%s\" or \"%s\" is accepted.", kPNGDataUriPrefix, kJPEGDataUriPrefix);
+        } else {
+          error_ = base::StringPrintf("Invalid data URI. Only \"%s\" or \"%s\" is accepted.", kPNGDataUriPrefix, kJPEGDataUriPrefix);
+          return false;
+        }
+      }
+
+      std::string decoded_str;
+      if (!base::Base64Decode(content, &decoded_str)) {
+        error_ = "Bad base64 string";
         return false;
       }
-    }
 
-    std::string decoded_str;
-    if (!base::Base64Decode(content, &decoded_str)) {
-      *error = "Bad base64 string";
-      return false;
-    }
-
-    scoped_ptr<SkBitmap> bitmap(new SkBitmap());
-    if (params->type == TYPE_PNG &&
-      !gfx::PNGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size(), bitmap.get())) {
-      *error = "Failed to decode as PNG";
-      return false;
-    } else if (params->type == TYPE_JPEG) {
-      SkBitmap* tmp_bitmap = gfx::JPEGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size());
-      if (tmp_bitmap == NULL) {
-        *error = "Failed to decode as JPEG";
+      scoped_ptr<SkBitmap> bitmap(new SkBitmap());
+      if (data.type == TYPE_PNG &&
+        !gfx::PNGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size(), bitmap.get())) {
+        error_ = "Failed to decode as PNG";
         return false;
+      } else if (data.type == TYPE_JPEG) {
+        SkBitmap* tmp_bitmap = gfx::JPEGCodec::Decode(reinterpret_cast<const unsigned char*>(decoded_str.c_str()), decoded_str.size());
+        if (tmp_bitmap == NULL) {
+          error_ = "Failed to decode as JPEG";
+          return false;
+        }
+        bitmap.reset(tmp_bitmap);
       }
-      bitmap.reset(tmp_bitmap);
+
+      scw_->WriteImage(*bitmap);
+
+      return true;
     }
 
-    scw.WriteImage(*bitmap);
-  } else if (params->type == TYPE_HTML) {
-    scw.WriteHTML(base::UTF8ToUTF16(params->content), std::string());
-  } else if (params->type == TYPE_RTF) {
-    scw.WriteRTF(params->content);
-  } else {
-    NOTREACHED();
-    return false;
+    std::string error_;
+    scoped_ptr<ui::ScopedClipboardWriter> scw_;
+  };
+}
+
+NwClipboardGetListSyncFunction::NwClipboardGetListSyncFunction() {
+}
+
+NwClipboardGetListSyncFunction::~NwClipboardGetListSyncFunction() {
+}
+
+bool NwClipboardGetListSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
+  scoped_ptr<GetListSync::Params> params(GetListSync::Params::Create(*args_));
+  EXTENSION_FUNCTION_VALIDATE(params.get());
+  scoped_ptr<ClipboardReader> reader(new ClipboardReader());
+
+  for(auto& data : params->data) {
+    if (!reader->Read(data)) {
+      *error = reader->error();
+      return false;
+    }
+    response->Append(data.ToValue());
+  }
+
+  return true;
+}
+
+NwClipboardSetListSyncFunction::NwClipboardSetListSyncFunction() {
+}
+
+NwClipboardSetListSyncFunction::~NwClipboardSetListSyncFunction() {
+}
+
+bool NwClipboardSetListSyncFunction::RunNWSync(base::ListValue* response, std::string* error) {
+  scoped_ptr<SetListSync::Params> params(SetListSync::Params::Create(*args_));
+  EXTENSION_FUNCTION_VALIDATE(params.get());
+  scoped_ptr<ClipboardWriter> writer(new ClipboardWriter());
+
+  for(auto& data : params->data) {
+    if (!writer->Write(data)) {
+      *error = writer->error();
+      writer->Reset();
+      return false;
+    }
   }
 
   return true;

--- a/src/api/nw_clipboard_api.h
+++ b/src/api/nw_clipboard_api.h
@@ -7,31 +7,31 @@
 
 namespace extensions {
 
-class NwClipboardGetSyncFunction : public NWSyncExtensionFunction {
+class NwClipboardGetListSyncFunction : public NWSyncExtensionFunction {
  public:
-  NwClipboardGetSyncFunction();
+  NwClipboardGetListSyncFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwClipboardGetSyncFunction() override;
+  ~NwClipboardGetListSyncFunction() override;
 
 
-  DECLARE_EXTENSION_FUNCTION("nw.Clipboard.getSync", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Clipboard.getListSync", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwClipboardGetSyncFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwClipboardGetListSyncFunction);
 };
 
-class NwClipboardSetSyncFunction : public NWSyncExtensionFunction {
+class NwClipboardSetListSyncFunction : public NWSyncExtensionFunction {
  public:
-  NwClipboardSetSyncFunction();
+  NwClipboardSetListSyncFunction();
   bool RunNWSync(base::ListValue* response, std::string* error) override;
 
  protected:
-  ~NwClipboardSetSyncFunction() override;
+  ~NwClipboardSetListSyncFunction() override;
 
-  DECLARE_EXTENSION_FUNCTION("nw.Clipboard.setSync", UNKNOWN)
+  DECLARE_EXTENSION_FUNCTION("nw.Clipboard.setListSync", UNKNOWN)
  private:
-  DISALLOW_COPY_AND_ASSIGN(NwClipboardSetSyncFunction);
+  DISALLOW_COPY_AND_ASSIGN(NwClipboardSetListSyncFunction);
 };
 
 class NwClipboardClearSyncFunction : public NWSyncExtensionFunction {

--- a/src/resources/api_nw_clipboard.js
+++ b/src/resources/api_nw_clipboard.js
@@ -6,13 +6,13 @@ var sendRequest = require('sendRequest');
 nw_binding.registerCustomHook(function(bindingsAPI) {
   var apiFunctions = bindingsAPI.apiFunctions;
 
-  ['getSync', 'setSync', 'clearSync'].forEach(function(nwSyncAPIName) {
+  ['clearSync', 'setListSync'].forEach(function(nwSyncAPIName) {
     apiFunctions.setHandleRequest(nwSyncAPIName, function() {
       return sendRequest.sendRequestSync(this.name, arguments, this.definition.parameters, {})[0];
     });
   });
 
-  ['readAvailableTypes'].forEach(function(nwSyncAPIName) {
+  ['readAvailableTypes', 'getListSync'].forEach(function(nwSyncAPIName) {
     apiFunctions.setHandleRequest(nwSyncAPIName, function() {
       return sendRequest.sendRequestSync(this.name, arguments, this.definition.parameters, {});
     });
@@ -35,10 +35,36 @@ NWClipboard.get = function() {
 };
 
 NWClipboard.prototype.get = function (type, raw) {
-  return nwClipboardBinding.getSync(type || 'text', !!raw);
+  var toString = $Object.prototype.toString;
+  // get(ClipboardData[])
+  if (arguments.length === 1 && toString.apply(type) === '[object Array]') {
+    return nwClipboardBinding.getListSync(type);
+  }
+  // get(DOMString, boolean)
+  if (!type || toString.apply(type) === '[object String]') {
+    return nwClipboardBinding.getListSync([{type: type || 'text', raw: !!raw}])[0].data;
+  }
+  // get(ClipboardData)
+  if (arguments.length === 1) {
+    return nwClipboardBinding.getListSync([type])[0].data;
+  }
+  throw new TypeException('Expecting get(string, optional boolean) or get(ClipboardData[]) or get(ClipboardData).');
 };
 NWClipboard.prototype.set = function (content, type, raw) {
-  return nwClipboardBinding.setSync(content, type || 'text', !!raw);
+  var toString = $Object.prototype.toString;
+  // set(ClipboardData[])
+  if (arguments.length === 1 && toString.apply(content) === '[object Array]') {
+    return nwClipboardBinding.setListSync(content);
+  }
+  // set(DOMString, DOMString, boolean)
+  if (toString.apply(content) === '[object String]') {
+    return nwClipboardBinding.setListSync([{type: type || 'text', raw: !!raw, data: content}]);
+  }
+  // set(ClipboardData)
+  if (arguments.length === 1) {
+    return nwClipboardBinding.setListSync([content]);
+  }
+  throw new TypeException('Expecting set(string, optional string, optional boolean) or set(ClipboardData[]) or set(ClipboardData).');
 };
 NWClipboard.prototype.clear = function () {
   return nwClipboardBinding.clearSync();


### PR DESCRIPTION
following new APIs added:
* `clip.set(clipboardDataList)`
* `clip.set(clipboardData)`
* `clip.get(clipboardDataList)`
* `clip.get(clipboardData)`

fixed #4929