### PR TITLE
Disabled contextual menu plug-in items on mac.

### DIFF
--- a/src/api/menu/menu_mac.mm
+++ b/src/api/menu/menu_mac.mm
@@ -36,6 +36,7 @@ namespace nw {
 void Menu::Create(const base::DictionaryValue& option) {
   menu_ = [[NSMenu alloc] initWithTitle:@"NW Menu"];
   [menu_ setAutoenablesItems:NO];
+  [menu_ setAllowsContextMenuPlugIns:NO];
   menu_delegate_ = [[NWMenuDelegate alloc] initWithMenu:this];
   [menu_ setDelegate:menu_delegate_];
 }


### PR DESCRIPTION
Disabled contextual menu plug-in items on mac.
![menu](https://cloud.githubusercontent.com/assets/4130931/15982354/94c8a38a-2f85-11e6-8522-67859781a342.jpg)
