### PR TITLE
updated Window.md `win.print()` call

### DIFF
--- a/docs/References/Window.md
+++ b/docs/References/Window.md
@@ -308,6 +308,8 @@ Print the web contents in the window without the need for user's interaction. `o
 
 `mediaSize` example: `'mediaSize':{'name': 'CUSTOM', 'width_microns': 279400, 'height_microns': 215900, 'custom_display_name':'Letter', 'is_default': true}`
 
+*NOTE: If no options are being passed, `win.print({})` is what should be called.*
+
 ## win.setMaximumSize(width, height)
 
 * `width` `{Integer}` the maximum width of the window


### PR DESCRIPTION
If no options are passed to `win.print()`, then `win.print({})` needs to be called because `win.print()` expects an object.