### PR TITLE
Make Window.eval() and Window.evalNWBin() return result

### DIFF
--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -399,10 +399,10 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
       currentNWWindowInternal.reloadIgnoringCache();
     };
     NWWindow.prototype.eval = function (frame, script) {
-      nwNatives.evalScript(frame, script);
+      return nwNatives.evalScript(frame, script);
     };
     NWWindow.prototype.evalNWBin = function (frame, path) {
-      nwNatives.evalNWBin(frame, path);
+      return nwNatives.evalNWBin(frame, path);
     };
     NWWindow.prototype.show = function () {
       this.appWindow.show();


### PR DESCRIPTION
This fixes a regression since nw13 where the return value of Window.eval() and Window.evalNWBin() would be lost.

BTW, it would be great if this could also be merged into the nw14 branch.