### PR TITLE
[linux] fixed foreground colors for menubar

### DIFF
--- a/src/browser/menubar_view.cc
+++ b/src/browser/menubar_view.cc
@@ -46,6 +46,11 @@ class MenuBarButton : public views::MenuButton {
     return !tooltip->empty();
   }
 
+  void OnNativeThemeChanged(const ui::NativeTheme* theme) override {
+    views::MenuButton::OnNativeThemeChanged(theme);
+    SetEnabledTextColors(theme->GetSystemColor(ui::NativeTheme::kColorId_EnabledMenuItemForegroundColor));
+  }
+
  private:
 
   DISALLOW_COPY_AND_ASSIGN(MenuBarButton);
@@ -107,8 +112,11 @@ void MenuBarView::ButtonPressed(views::Button* sender,
 }
 
 void MenuBarView::OnNativeThemeChanged(const ui::NativeTheme* theme) {
-  set_background(views::Background::CreateSolidBackground(GetNativeTheme()->
+  // Use menu background color for menubar
+  set_background(views::Background::CreateSolidBackground(theme->
        GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor)));
+  // Force to repaint the menubar
+  SchedulePaint();
 }
 
 } //namespace nw


### PR DESCRIPTION
Foreground colors used by menubar buttons should be consistent
with themes provided by the system. We use same foreground color
as menu items.

fixed #5007