### PR TITLE
Table of Contents keeps changing in each version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,48 +11,4 @@ The document is structured in three major parts:
 
 The source of the document is in [our git repo](https://github.com/nwjs/nw.js/tree/nw13/docs). PRs are welcome.
 
-## Table of Contents
-
-* [Homepage](index.md)
-* For Users
-    - [Getting Started](For Users/Getting Started.md)
-    - [Debugging with DevTools](For Users/Debugging with DevTools.md)
-    - [Package and Distribute](For Users/Package and Distribute.md)
-    - [FAQ](For Users/FAQ.md)
-    - [From 0.12 to 0.13](For Users/Migration/From 0.12 to 0.13.md)
-    - Advanced
-        + [Build Flavors](For Users/Advanced/Build Flavors.md)
-        + [JavaScript Contexts in NW.js](For Users/Advanced/JavaScript Contexts in NW.js.md)
-        + [Protect JavaScript Source Code](For Users/Advanced/Protect JavaScript Source Code.md)
-        + [Security in NW.js](For Users/Advanced/Security in NW.js.md)
-        + [Test with ChromeDriver](For Users/Advanced/Test with ChromeDriver.md)
-        + [Use Flash Plugin](For Users/Advanced/Use Flash Plugin.md)
-        + [Use NaCl in NW.js](For Users/Advanced/Use NaCl in NW.js.md)
-        + [Use Native Node Modules](For Users/Advanced/Use Native Node Modules.md)
-        + [Content Verification](For Users/Advanced/Content Verification.md)
-        + [Customize Menubar](For Users/Advanced/Customize Menubar.md)
-* For Developers
-    - [Building NW.js](For Developers/Building NW.js.md)
-    - [Contributing to NW.js](For Developers/Contributing to NW.js.md)
-    - [Enable Proprietary Codecs](For Developers/Enable Proprietary Codecs.md)
-    - [Repositories](For Developers/Repositories.md)
-    - [Understanding Crash Dump](For Developers/Understanding Crash Dump.md)
-    - [Writing Documents for NW.js](For Developers/Writing Documents for NW.js.md)
-    - [Writing Test Cases for NW.js](For Developers/Writing Test Cases for NW.js.md)
-    - [Contributors of Documents](For Developers/Contributors of Documents.md)
-* References
-    - [App](References/App.md)
-    - [Changes to DOM](References/Changes to DOM.md)
-    - [Changes to Node](References/Changes to Node.md)
-    - [Clipboard](References/Clipboard.md)
-    - [Command Line Options](References/Command Line Options.md)
-    - [Chrome Extension APIs](References/Chrome Extension APIs.md)
-    - [Manifest Format](References/Manifest Format.md)
-    - [Menu](References/Menu.md)
-    - [MenuItem](References/MenuItem.md)
-    - [Screen](References/Screen.md)
-    - [Shell](References/Shell.md)
-    - [Shortcut](References/Shortcut.md)
-    - [Tray](References/Tray.md)
-    - [webview Tag](References/webview Tag.md)
-    - [Window](References/Window.md)
+## Start By Reading The Friendly -> ["Getting Started" Page](http://docs.nwjs.io/en/latest/For%20Users/Getting%20Started/)


### PR DESCRIPTION
Table of Contents keeps changing in each version of documentation and the one shown previously has several missing links and doesn't follow navigation structure on right menu causing confusion in first-time-readers mind, while fixing it once is not a permanent solution in long term. 
So it is wise to allow user to start from reading the friendly "Getting Started" Page itself and let the document navigation(next buttons below every page & right side navigation) take them places instead.