### PR TITLE
Revert "[docs] native module with npm"

### DIFF
--- a/docs/For Users/Advanced/Use Native Node Modules.md
+++ b/docs/For Users/Advanced/Use Native Node Modules.md
@@ -3,14 +3,7 @@
 
 [TOC]
 
-`npm` tool provided by Node.js builds the native modules, i.e. [C/C++ Addons](https://nodejs.org/api/addons.html), at the time of installation.
-
-Starting from 0.13.0, native modules built by node-gyp or npm in upstream can be supported.
-
-In Linux and OSX you can just load the native module directly. In windows you'll need to replace the file
-%APPDATA%\npm\node_modules\node-gyp\src\win_delay_load_hook.c with the one at https://github.com/nwjs/nw.js/blob/nw13/tools/win_delay_load_hook.c 
-
-Before 0.13.0, the V8 version and Node API in NW.js is different from official Node.js. To use native Node.js modules with NW.js, you have to rebuild the modules with one of following tools.
+`npm` tool provided by Node.js builds the native modules, i.e. [C/C++ Addons](https://nodejs.org/api/addons.html), at the time of installation. However the V8 version and Node API in NW.js is different from official Node.js. To use native Node.js modules with NW.js, you have to rebuild the modules with one of following tools.
 
 ## nw-gyp
 


### PR DESCRIPTION
Due to V8 differences (#5025), native modules built from npm or
node-gyp can't be used by NW.js 0.15.x directly. Remove the docs
about the usage of npm & node-gyp.

This reverts commit 9f2a798bdab5c50cbd0cb480141d8fdefa989f48.