### PR TITLE
do not return invalid shortcuts for menu items

### DIFF
--- a/src/api/menu/menu_delegate.cc
+++ b/src/api/menu/menu_delegate.cc
@@ -75,6 +75,9 @@ bool MenuDelegate::GetAcceleratorForCommandId(
   if (!item)
     return false;
 
+  if (!item->enable_shortcut_)
+    return false;
+
   *accelerator = item->accelerator_;
   return true;
 }

--- a/src/api/menuitem/menuitem_views.cc
+++ b/src/api/menuitem/menuitem_views.cc
@@ -204,7 +204,7 @@ bool MenuItem::AcceleratorPressed(const ui::Accelerator& accelerator) {
 }
 
 bool MenuItem::CanHandleAccelerators() const {
-  return is_enabled_;
+  return enable_shortcut_ && is_enabled_;
 }
 
 #endif


### PR DESCRIPTION
fixed #5026 

@rogerwang This is a patch for issues on NW14 for Win XP. If you think necessary for NW16, please merge this patch.