### PR TITLE
fixed arguments passed to `nw.Window` API callbacks

### DIFF
--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -267,7 +267,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
       case 'navigation':
         var j = wrap(function(frame, url, policy, context) {
           policy.ignore         =  function () { this.val = 'ignore'; };
-          callback.call(this, frame, url, policy, context);
+          callback.call(self, frame, url, policy, context);
         });
         this.onNavigation.addListener(j);
         break;
@@ -280,7 +280,7 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
         break;
       case 'resize':
         var l = wrap(function() {
-          callback.call(self.width, self.height);
+          callback.call(self, self.width, self.height);
         });
         this.appWindow.onResized.addListener(l);
         return this; //return early


### PR DESCRIPTION
Two bugs brings from commit bc016d4:
* missing `height` argument to `resize` event (fixed #4993)
* should use `self` instead of `this` in `navigation` event callbacks