### PR TITLE
Updated win_delay_load_hook.c to work with node-gyp@3.4.0

### DIFF
--- a/tools/win_delay_load_hook.cc
+++ b/tools/win_delay_load_hook.cc
@@ -9,7 +9,10 @@
 
 #ifdef _MSC_VER
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <windows.h>
 
 #include <delayimp.h>
@@ -42,6 +45,6 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) node_dll;
 }
 
-PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 
 #endif


### PR DESCRIPTION
Made the modifications I talked about in issue #5088 .

Changed `PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;` to `decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;` so it'll work with the new VS build tools on Windows.

Also added the header guard.

e: Quick edit, here's the PR from node-gyp discussing the change:

https://github.com/nodejs/node-gyp/pull/952