### PR TITLE
activate menuitem of menubar button when clicked

### DIFF
--- a/src/browser/menubar_view.cc
+++ b/src/browser/menubar_view.cc
@@ -105,6 +105,7 @@ void MenuBarView::OnMenuButtonClicked(views::MenuButton* view,
     MenuBarController* controller = new MenuBarController(this, model_->GetSubmenuModelAt(button_index), NULL);
     controller->RunMenuAt(view, point);
   }
+  model_->ActivatedAt(button_index, event->flags());
 }
 
 void MenuBarView::ButtonPressed(views::Button* sender,


### PR DESCRIPTION
fixed #5150 

This feature existed in pre-13 releases. It should be supported.