### PR TITLE
[linux] enabled global menubar on Ubuntu

### DIFF
--- a/docs/References/Menu.md
+++ b/docs/References/Menu.md
@@ -59,6 +59,7 @@ See [Customize Menubar](../For Users/Advanced/Customize Menubar.md) for detailed
 
 * `option` `{Object}` _Optional_
     - `type` `{String}` _Optional_ two types are accepted by this method: "menubar" or "contextmenu". The value is set to "contextmenu" by default.
+    - `global` `{Boolean}` _Optional_ *(Linux Only)* specify if using global menubar on Ubuntu. It will fallback to local window based menubar if no global menubar available. The value is set to `false` by default.
 
 Create a `Menu` object.
 

--- a/nw.gypi
+++ b/nw.gypi
@@ -143,6 +143,14 @@
             'src/browser/menubar_controller.h',
           ],
         }],
+        ['OS=="linux"', {
+          'sources': [
+            'src/browser/global_menu_bar_registrar_x11.cc',
+            'src/browser/global_menu_bar_registrar_x11.h',
+            'src/browser/global_menu_bar_x11.cc',
+            'src/browser/global_menu_bar_x11.h',
+          ],
+        }],
         ['OS=="mac"', {
           'sources': [
             'src/api/base/base_mac.h',

--- a/src/api/menu/menu.h
+++ b/src/api/menu/menu.h
@@ -135,6 +135,8 @@ class Menu : public Base {
   // rebuild the menu before next show.
   bool is_menu_modified_;
 
+  bool is_global_menu_bar_;
+
   std::unique_ptr<MenuDelegate> menu_delegate_;
   std::unique_ptr<ui::NwMenuModel> menu_model_;
 #endif

--- a/src/api/menu/menu_views.cc
+++ b/src/api/menu/menu_views.cc
@@ -60,7 +60,8 @@ void Menu::Create(const base::DictionaryValue& option) {
   focus_manager_ = NULL;
   window_ = NULL;
 
-  std::string type;
+  is_global_menu_bar_ = false;
+  option.GetBoolean("global", &is_global_menu_bar_);
 
   menu_items_.empty();
 }

--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -26,6 +26,8 @@
 
 #include "content/nw/src/api/nw_current_window_internal.h"
 
+#include "chrome/browser/ui/webui/print_preview/print_preview_handler.h"
+
 #if defined(OS_WIN)
 #include <shobjidl.h>
 #include <dwmapi.h>
@@ -42,6 +44,9 @@
 
 #if defined(OS_LINUX)
 #include "chrome/browser/ui/libgtk2ui/gtk2_ui.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
+#include "ui/aura/window.h"
+#include "content/nw/src/browser/global_menu_bar_x11.h"
 #endif
 
 #if defined(OS_LINUX) || defined(OS_WIN)
@@ -53,8 +58,6 @@ using nw::BrowserViewLayout;
 #if defined(OS_MACOSX)
 #include "content/nw/src/nw_content_mac.h"
 #endif
-
-#include "chrome/browser/ui/webui/print_preview/print_preview_handler.h"
 
 using content::RenderWidgetHost;
 using content::RenderWidgetHostView;
@@ -327,6 +330,14 @@ bool NwCurrentWindowInternalClearMenuFunction::RunAsync() {
 #endif
 
 #if defined(OS_LINUX) || defined(OS_WIN)
+
+#if defined(OS_LINUX)
+  if (nw::GlobalMenuBarX11::IsGlobalMenuBarEnabled()) {
+    views::DesktopWindowTreeHostX11 *host = static_cast<views::DesktopWindowTreeHostX11*>(window->GetNativeWindow()->GetHost());
+    host->SetGlobalMenu(nullptr);
+  }
+#endif
+
   native_app_window::NativeAppWindowViews* native_app_window_views =
       static_cast<native_app_window::NativeAppWindowViews*>(
           window->GetBaseWindow());
@@ -369,6 +380,16 @@ bool NwCurrentWindowInternalSetMenuFunction::RunNWSync(base::ListValue* response
   native_app_window::NativeAppWindowViews* native_app_window_views =
       static_cast<native_app_window::NativeAppWindowViews*>(
           window->GetBaseWindow());
+  menu->UpdateKeys( native_app_window_views->widget()->GetFocusManager() );
+
+#if defined(OS_LINUX)
+  if (menu->is_global_menu_bar_ && nw::GlobalMenuBarX11::IsGlobalMenuBarEnabled()) {
+    views::DesktopWindowTreeHostX11 *host = static_cast<views::DesktopWindowTreeHostX11*>(window->GetNativeWindow()->GetHost());
+    host->SetGlobalMenu(menu->model());
+    response->Append(std::unique_ptr<base::ListValue>(new base::ListValue()));
+    return true;
+  }
+#endif
 
   MenuBarView* menubar = new MenuBarView();
   static_cast<BrowserViewLayout*>(native_app_window_views->GetLayoutManager())->set_menu_bar(menubar);
@@ -376,9 +397,9 @@ bool NwCurrentWindowInternalSetMenuFunction::RunNWSync(base::ListValue* response
   menubar->UpdateMenu(menu->model());
   native_app_window_views->layout_();
   native_app_window_views->SchedulePaint();
-  menu->UpdateKeys( native_app_window_views->widget()->GetFocusManager() );
   response->Append(std::unique_ptr<base::ListValue>(new base::ListValue()));
 #endif
+
   return true;
 }
   

--- a/src/browser/global_menu_bar_registrar_x11.cc
+++ b/src/browser/global_menu_bar_registrar_x11.cc
@@ -1,0 +1,143 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/nw/src/browser/global_menu_bar_registrar_x11.h"
+
+#include "base/bind.h"
+#include "base/debug/leak_annotations.h"
+#include "base/logging.h"
+#include "content/nw/src/browser/global_menu_bar_x11.h"
+
+namespace nw {
+
+namespace {
+
+const char kAppMenuRegistrarName[] = "com.canonical.AppMenu.Registrar";
+const char kAppMenuRegistrarPath[] = "/com/canonical/AppMenu/Registrar";
+
+}  // namespace
+
+// static
+GlobalMenuBarRegistrarX11* GlobalMenuBarRegistrarX11::GetInstance() {
+  return base::Singleton<GlobalMenuBarRegistrarX11>::get();
+}
+
+void GlobalMenuBarRegistrarX11::OnWindowMapped(unsigned long xid) {
+  live_xids_.insert(xid);
+
+  if (registrar_proxy_)
+    RegisterXID(xid);
+}
+
+void GlobalMenuBarRegistrarX11::OnWindowUnmapped(unsigned long xid) {
+  if (registrar_proxy_)
+    UnregisterXID(xid);
+
+  live_xids_.erase(xid);
+}
+
+GlobalMenuBarRegistrarX11::GlobalMenuBarRegistrarX11()
+    : registrar_proxy_(nullptr) {
+  // libdbusmenu uses the gio version of dbus; I tried using the code in dbus/,
+  // but it looks like that's isn't sharing the bus name with the gio version,
+  // even when |connection_type| is set to SHARED.
+  g_dbus_proxy_new_for_bus(
+      G_BUS_TYPE_SESSION,
+      static_cast<GDBusProxyFlags>(
+          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES |
+          G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS |
+          G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START),
+      nullptr,
+      kAppMenuRegistrarName,
+      kAppMenuRegistrarPath,
+      kAppMenuRegistrarName,
+      nullptr,  // TODO: Probalby want a real cancelable.
+      static_cast<GAsyncReadyCallback>(OnProxyCreatedThunk),
+      this);
+}
+
+GlobalMenuBarRegistrarX11::~GlobalMenuBarRegistrarX11() {
+  if (registrar_proxy_) {
+    g_signal_handlers_disconnect_by_func(
+        registrar_proxy_,
+        reinterpret_cast<void*>(OnNameOwnerChangedThunk),
+        this);
+    g_object_unref(registrar_proxy_);
+  }
+}
+
+void GlobalMenuBarRegistrarX11::RegisterXID(unsigned long xid) {
+  DCHECK(registrar_proxy_);
+  std::string path = GlobalMenuBarX11::GetPathForWindow(xid);
+
+  ANNOTATE_SCOPED_MEMORY_LEAK; // http://crbug.com/314087
+  // TODO(erg): The mozilla implementation goes to a lot of callback trouble
+  // just to make sure that they react to make sure there's some sort of
+  // cancelable object; including making a whole callback just to handle the
+  // cancelable.
+  //
+  // I don't see any reason why we should care if "RegisterWindow" completes or
+  // not.
+  g_dbus_proxy_call(registrar_proxy_,
+                    "RegisterWindow",
+                    g_variant_new("(uo)", xid, path.c_str()),
+                    G_DBUS_CALL_FLAGS_NONE, -1,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+}
+
+void GlobalMenuBarRegistrarX11::UnregisterXID(unsigned long xid) {
+  DCHECK(registrar_proxy_);
+  std::string path = GlobalMenuBarX11::GetPathForWindow(xid);
+
+  ANNOTATE_SCOPED_MEMORY_LEAK; // http://crbug.com/314087
+  // TODO(erg): The mozilla implementation goes to a lot of callback trouble
+  // just to make sure that they react to make sure there's some sort of
+  // cancelable object; including making a whole callback just to handle the
+  // cancelable.
+  //
+  // I don't see any reason why we should care if "UnregisterWindow" completes
+  // or not.
+  g_dbus_proxy_call(registrar_proxy_,
+                    "UnregisterWindow",
+                    g_variant_new("(u)", xid),
+                    G_DBUS_CALL_FLAGS_NONE, -1,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+}
+
+void GlobalMenuBarRegistrarX11::OnProxyCreated(GObject* source,
+                                               GAsyncResult* result) {
+  GError* error = nullptr;
+  GDBusProxy* proxy = g_dbus_proxy_new_for_bus_finish(result, &error);
+  if (error) {
+    g_error_free(error);
+    return;
+  }
+
+  // TODO(erg): Mozilla's implementation has a workaround for GDBus
+  // cancellation here. However, it's marked as fixed. If there's weird
+  // problems with cancelation, look at how they fixed their issues.
+
+  registrar_proxy_ = proxy;
+
+  g_signal_connect(registrar_proxy_, "notify::g-name-owner",
+                   G_CALLBACK(OnNameOwnerChangedThunk), this);
+
+  OnNameOwnerChanged(nullptr, nullptr);
+}
+
+void GlobalMenuBarRegistrarX11::OnNameOwnerChanged(GObject* /* ignored */,
+                                                   GParamSpec* /* ignored */) {
+  // If the name owner changed, we need to reregister all the live xids with
+  // the system.
+  for (std::set<unsigned long>::const_iterator it = live_xids_.begin();
+       it != live_xids_.end(); ++it) {
+    RegisterXID(*it);
+  }
+}
+
+} // namespace nw

--- a/src/browser/global_menu_bar_registrar_x11.h
+++ b/src/browser/global_menu_bar_registrar_x11.h
@@ -1,0 +1,60 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// NW fix: modified from src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h
+
+#ifndef CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_REGISTRAR_X11_H_
+#define CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_REGISTRAR_X11_H_
+
+#include <gio/gio.h>
+
+#include <set>
+
+#include "base/macros.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/singleton.h"
+#include "ui/base/glib/glib_signal.h"
+
+namespace nw {
+
+// Advertises our menu bars to Unity.
+//
+// GlobalMenuBarX11 is responsible for managing the DbusmenuServer for each
+// XID. We need a separate object to own the dbus channel to
+// com.canonical.AppMenu.Registrar and to register/unregister the mapping
+// between a XID and the DbusmenuServer instance we are offering.
+class GlobalMenuBarRegistrarX11 {
+ public:
+  static GlobalMenuBarRegistrarX11* GetInstance();
+
+  void OnWindowMapped(unsigned long xid);
+  void OnWindowUnmapped(unsigned long xid);
+
+ private:
+  friend struct base::DefaultSingletonTraits<GlobalMenuBarRegistrarX11>;
+
+  GlobalMenuBarRegistrarX11();
+  ~GlobalMenuBarRegistrarX11();
+
+  // Sends the actual message.
+  void RegisterXID(unsigned long xid);
+  void UnregisterXID(unsigned long xid);
+
+  CHROMEG_CALLBACK_1(GlobalMenuBarRegistrarX11, void, OnProxyCreated,
+                     GObject*, GAsyncResult*);
+  CHROMEG_CALLBACK_1(GlobalMenuBarRegistrarX11, void, OnNameOwnerChanged,
+                     GObject*, GParamSpec*);
+
+  GDBusProxy* registrar_proxy_;
+
+  // Window XIDs which want to be registered, but haven't yet been because
+  // we're waiting for the proxy to become available.
+  std::set<unsigned long> live_xids_;
+
+  DISALLOW_COPY_AND_ASSIGN(GlobalMenuBarRegistrarX11);
+};
+
+} // namespace nw
+
+#endif  // CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_REGISTRAR_X11_H_

--- a/src/browser/global_menu_bar_x11.cc
+++ b/src/browser/global_menu_bar_x11.cc
@@ -1,0 +1,348 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/nw/src/browser/global_menu_bar_x11.h"
+
+#include <dlfcn.h>
+#include <glib-object.h>
+#include <stddef.h>
+
+#include "base/debug/leak_annotations.h"
+#include "base/logging.h"
+#include "base/macros.h"
+#include "base/stl_util.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h"
+#include "content/nw/src/browser/global_menu_bar_registrar_x11.h"
+#include "chrome/grit/generated_resources.h"
+// #include "grit/components_strings.h"
+#include "ui/base/accelerators/menu_label_accelerator_util_linux.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
+#include "ui/gfx/text_elider.h"
+#include "ui/base/models/menu_model.h"
+
+#define DLSYM_DBUSMENU_FUNC(name) \
+  name = \
+      reinterpret_cast<dbusmenu_ ## name ## _func>( \
+          dlsym(dbusmenu_lib, "dbusmenu_" # name)); \
+  if (!name) return false;
+
+namespace nw {
+
+// libdbusmenu-glib types
+typedef struct _DbusmenuMenuitem DbusmenuMenuitem;
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_new_func)();
+typedef bool (*dbusmenu_menuitem_child_add_position_func)(
+    DbusmenuMenuitem* parent,
+    DbusmenuMenuitem* child,
+    unsigned int position);
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_child_append_func)(
+    DbusmenuMenuitem* parent,
+    DbusmenuMenuitem* child);
+typedef bool (*dbusmenu_menuitem_child_delete_func)(
+    DbusmenuMenuitem* parent,
+    DbusmenuMenuitem* child);
+typedef GList* (*dbusmenu_menuitem_get_children_func)(
+    DbusmenuMenuitem* item);
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_func)(
+    DbusmenuMenuitem* item,
+    const char* property,
+    const char* value);
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_variant_func)(
+    DbusmenuMenuitem* item,
+    const char* property,
+    GVariant* value);
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_bool_func)(
+    DbusmenuMenuitem* item,
+    const char* property,
+    bool value);
+typedef DbusmenuMenuitem* (*dbusmenu_menuitem_property_set_int_func)(
+    DbusmenuMenuitem* item,
+    const char* property,
+    int value);
+
+typedef struct _DbusmenuServer      DbusmenuServer;
+typedef DbusmenuServer* (*dbusmenu_server_new_func)(const char* object);
+typedef void (*dbusmenu_server_set_root_func)(DbusmenuServer* self,
+                                              DbusmenuMenuitem* root);
+
+namespace {
+
+// Retrieved functions from libdbusmenu-glib.
+
+// DbusmenuMenuItem methods:
+dbusmenu_menuitem_new_func menuitem_new = nullptr;
+dbusmenu_menuitem_get_children_func menuitem_get_children = nullptr;
+dbusmenu_menuitem_child_add_position_func menuitem_child_add_position = nullptr;
+dbusmenu_menuitem_child_append_func menuitem_child_append = nullptr;
+dbusmenu_menuitem_child_delete_func menuitem_child_delete = nullptr;
+dbusmenu_menuitem_property_set_func menuitem_property_set = nullptr;
+dbusmenu_menuitem_property_set_variant_func menuitem_property_set_variant =
+    nullptr;
+dbusmenu_menuitem_property_set_bool_func menuitem_property_set_bool = nullptr;
+dbusmenu_menuitem_property_set_int_func menuitem_property_set_int = nullptr;
+
+// DbusmenuServer methods:
+dbusmenu_server_new_func server_new = nullptr;
+dbusmenu_server_set_root_func server_set_root = nullptr;
+
+// Properties that we set on menu items:
+const char kPropertyEnabled[] = "enabled";
+const char kPropertyLabel[] = "label";
+const char kPropertyShortcut[] = "shortcut";
+const char kPropertyType[] = "type";
+const char kPropertyToggleType[] = "toggle-type";
+const char kPropertyToggleState[] = "toggle-state";
+const char kPropertyVisible[] = "visible";
+const char kPropertyChildrenDisplay[] = "children-display";
+
+const char kTypeCheckmark[] = "checkmark";
+const char kTypeSeparator[] = "separator";
+const char kTypeSubmenu[] = "submenu";
+
+// Data set on GObjectgs.
+const char kTypeTag[] = "type-tag";
+
+// static
+bool EnsureMethodsLoaded() {
+  static bool attempted_load = false;
+  if (attempted_load)
+    return true;
+
+  void* dbusmenu_lib = dlopen("libdbusmenu-glib.so", RTLD_LAZY);
+  if (!dbusmenu_lib)
+    dbusmenu_lib = dlopen("libdbusmenu-glib.so.4", RTLD_LAZY);
+  if (!dbusmenu_lib)
+    return false;
+
+  // DbusmenuMenuItem methods.
+  DLSYM_DBUSMENU_FUNC(menuitem_new)
+  DLSYM_DBUSMENU_FUNC(menuitem_child_add_position)
+  DLSYM_DBUSMENU_FUNC(menuitem_child_append)
+  DLSYM_DBUSMENU_FUNC(menuitem_child_delete)
+  DLSYM_DBUSMENU_FUNC(menuitem_get_children)
+  DLSYM_DBUSMENU_FUNC(menuitem_property_set)
+  DLSYM_DBUSMENU_FUNC(menuitem_property_set_variant)
+  DLSYM_DBUSMENU_FUNC(menuitem_property_set_bool)
+  DLSYM_DBUSMENU_FUNC(menuitem_property_set_int)
+
+  // DbusmenuServer methods.
+  DLSYM_DBUSMENU_FUNC(server_new)
+  DLSYM_DBUSMENU_FUNC(server_set_root)
+
+  attempted_load = true;
+
+  return true;
+}
+
+}  // namespace
+
+GlobalMenuBarX11::GlobalMenuBarX11(views::DesktopWindowTreeHostX11* host, ui::MenuModel* model)
+    : host_(host),
+      server_(nullptr),
+      root_item_(nullptr),
+      model_(model),
+      weak_ptr_factory_(this) {
+  EnsureMethodsLoaded();
+
+  if (server_new) {
+    host_->AddObserver(this);
+    OnWindowMapped(host_->GetAcceleratedWidget());
+  }
+}
+
+GlobalMenuBarX11::~GlobalMenuBarX11() {
+  if (server_) {
+    g_object_unref(server_);
+    host_->RemoveObserver(this);
+    OnWindowUnmapped(host_->GetAcceleratedWidget());
+  }
+}
+
+// static
+std::string GlobalMenuBarX11::GetPathForWindow(unsigned long xid) {
+  return base::StringPrintf("/com/canonical/menu/%lX", xid);
+}
+
+// static
+bool GlobalMenuBarX11::IsGlobalMenuBarEnabled() {
+  return EnsureMethodsLoaded();
+}
+
+DbusmenuMenuitem* GlobalMenuBarX11::BuildSeparator() {
+  DbusmenuMenuitem* item = menuitem_new();
+  menuitem_property_set(item, kPropertyType, kTypeSeparator);
+  menuitem_property_set_bool(item, kPropertyVisible, true);
+  return item;
+}
+
+DbusmenuMenuitem* GlobalMenuBarX11::BuildMenuItem(
+    const std::string& label,
+    int tag_id) {
+  DbusmenuMenuitem* item = menuitem_new();
+  menuitem_property_set(item, kPropertyLabel, label.c_str());
+  menuitem_property_set_bool(item, kPropertyVisible, true);
+
+  if (tag_id)
+    g_object_set_data(G_OBJECT(item), kTypeTag, GINT_TO_POINTER(tag_id));
+
+  return item;
+}
+
+void GlobalMenuBarX11::InitServer(unsigned long xid) {
+  std::string path = GetPathForWindow(xid);
+  {
+    ANNOTATE_SCOPED_MEMORY_LEAK; // http://crbug.com/314087
+    server_ = server_new(path.c_str());
+  }
+
+  root_item_ = menuitem_new();
+  menuitem_property_set(root_item_, kPropertyLabel, "Root");
+  menuitem_property_set_bool(root_item_, kPropertyVisible, true);
+
+  BuildStaticMenuFromModel(root_item_, model_);
+
+  server_set_root(server_, root_item_);
+}
+
+DbusmenuMenuitem* GlobalMenuBarX11::BuildStaticMenuFromModel(
+    DbusmenuMenuitem* parent, ui::MenuModel* model) {
+
+  for (int i = 0; i < model->GetItemCount(); ++i) {
+    DbusmenuMenuitem* menu_item = nullptr;
+    auto type = model->GetTypeAt(i);
+    if (type == ui::MenuModel::TYPE_SEPARATOR) {
+      menu_item = BuildSeparator();
+    } else {
+      int command_id = model->GetCommandIdAt(i);
+      std::string label = ui::ConvertAcceleratorsFromWindowsStyle(
+          base::UTF16ToUTF8(model->GetLabelAt(i)));
+
+      menu_item = BuildMenuItem(label, 0);
+
+      if (!model->IsEnabledAt(i)) {
+        menuitem_property_set_bool(menu_item, kPropertyEnabled, false);
+      } else {
+        if (type == ui::MenuModel::TYPE_CHECK) {
+          menuitem_property_set(menu_item, kPropertyToggleType, kTypeCheckmark);
+          menuitem_property_set_int(menu_item, kPropertyToggleState, model->IsItemCheckedAt(i));
+        } else if (type == ui::MenuModel::TYPE_SUBMENU) {
+          menuitem_property_set(menu_item, kPropertyChildrenDisplay, kTypeSubmenu);
+          // Submenus on root item should be added once, or it will trigger
+          // unnecessary "about-to-show" event.
+          if (parent == root_item_)
+            BuildStaticMenuFromModel(menu_item, model->GetSubmenuModelAt(i));
+          g_signal_connect(menu_item, "about-to-show",
+                         G_CALLBACK(OnSubMenuShowThunk), this);
+        }
+
+        g_object_set_data(G_OBJECT(menu_item), "command-id",
+                          GINT_TO_POINTER(command_id));
+        g_signal_connect(menu_item, "item-activated",
+                         G_CALLBACK(OnItemActivatedThunk), this);
+
+        ui::Accelerator accelerator;
+        if (model->GetAcceleratorAt(i, &accelerator)) {
+          RegisterAccelerator(menu_item, accelerator);
+        }
+      }
+    }
+
+    menuitem_child_append(parent, menu_item);
+    g_object_unref(menu_item);
+  }
+
+  return parent;
+}
+
+void GlobalMenuBarX11::RegisterAccelerator(DbusmenuMenuitem* item,
+                                           const ui::Accelerator& accelerator) {
+  // A translation of libdbusmenu-gtk's menuitem_property_set_shortcut()
+  // translated from GDK types to ui::Accelerator types.
+  GVariantBuilder builder;
+  g_variant_builder_init(&builder, G_VARIANT_TYPE_ARRAY);
+
+  if (accelerator.IsCmdDown())
+    g_variant_builder_add(&builder, "s", "Super");
+  if (accelerator.IsCtrlDown())
+    g_variant_builder_add(&builder, "s", "Control");
+  if (accelerator.IsAltDown())
+    g_variant_builder_add(&builder, "s", "Alt");
+  if (accelerator.IsShiftDown())
+    g_variant_builder_add(&builder, "s", "Shift");
+
+  char* name = XKeysymToString(XKeysymForWindowsKeyCode(
+      accelerator.key_code(), false));
+  if (!name) {
+    NOTIMPLEMENTED();
+    return;
+  }
+  g_variant_builder_add(&builder, "s", name);
+
+  GVariant* inside_array = g_variant_builder_end(&builder);
+  g_variant_builder_init(&builder, G_VARIANT_TYPE_ARRAY);
+  g_variant_builder_add_value(&builder, inside_array);
+  GVariant* outside_array = g_variant_builder_end(&builder);
+
+  menuitem_property_set_variant(item, kPropertyShortcut, outside_array);
+}
+
+void GlobalMenuBarX11::ClearMenuSection(DbusmenuMenuitem* menu) {
+  std::vector<DbusmenuMenuitem*> menuitems_to_delete;
+
+  GList* childs = menuitem_get_children(menu);
+  for (; childs != nullptr; childs = childs->next) {
+    DbusmenuMenuitem* current_item = reinterpret_cast<DbusmenuMenuitem*>(
+        childs->data);
+    ClearMenuSection(current_item);
+
+    menuitems_to_delete.push_back(current_item);
+  }
+
+  for (std::vector<DbusmenuMenuitem*>::const_iterator it =
+           menuitems_to_delete.begin(); it != menuitems_to_delete.end(); ++it) {
+    menuitem_child_delete(menu, *it);
+  }
+}
+
+void GlobalMenuBarX11::OnWindowMapped(unsigned long xid) {
+  if (!server_)
+    InitServer(xid);
+
+  GlobalMenuBarRegistrarX11::GetInstance()->OnWindowMapped(xid);
+}
+
+void GlobalMenuBarX11::OnWindowUnmapped(unsigned long xid) {
+  GlobalMenuBarRegistrarX11::GetInstance()->OnWindowUnmapped(xid);
+}
+
+void GlobalMenuBarX11::OnItemActivated(DbusmenuMenuitem* item,
+                                       unsigned int timestamp) {
+  int id = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(item), "command-id"));
+  ui::MenuModel* model = model_;
+  int index = -1;
+  if (ui::MenuModel::GetModelAndIndexForCommandId(id, &model, &index)) {
+    model->ActivatedAt(index);
+  }
+}
+
+void GlobalMenuBarX11::OnSubMenuShow(DbusmenuMenuitem* item) {
+  int id = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(item), "command-id"));
+  ui::MenuModel* model = model_;
+  int index = -1;
+  if (!ui::MenuModel::GetModelAndIndexForCommandId(id, &model, &index)) {
+    return;
+  }
+
+  ClearMenuSection(item);
+
+  BuildStaticMenuFromModel(item, model->GetSubmenuModelAt(index));
+
+  model->ActivatedAt(index);
+}
+
+} // namespace nw

--- a/src/browser/global_menu_bar_x11.h
+++ b/src/browser/global_menu_bar_x11.h
@@ -1,0 +1,97 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// NW fix: modified from src/chrome/browser/ui/views/frame/global_menu_bar_x11.h
+
+#ifndef CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_X11_H_
+#define CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_X11_H_
+
+#include <map>
+#include <string>
+
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "base/scoped_observer.h"
+#include "components/prefs/pref_change_registrar.h"
+#include "ui/base/glib/glib_signal.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_observer_x11.h"
+
+namespace ui {
+class Accelerator;
+class MenuModel;
+}
+
+namespace views {
+class DesktopWindowTreeHostX11;
+}
+
+namespace nw {
+typedef struct _DbusmenuMenuitem DbusmenuMenuitem;
+typedef struct _DbusmenuServer   DbusmenuServer;
+
+struct GlobalMenuBarCommand;
+
+// Controls the Mac style menu bar on Unity.
+//
+// Unity has an Apple-like menu bar at the top of the screen that changes
+// depending on the active window. In the GTK port, we had a hidden GtkMenuBar
+// object in each GtkWindow which existed only to be scrapped by the
+// libdbusmenu-gtk code. Since we don't have GtkWindows anymore, we need to
+// interface directly with the lower level libdbusmenu-glib, which we
+// opportunistically dlopen() since not everyone is running Ubuntu.
+class GlobalMenuBarX11 : public views::DesktopWindowTreeHostObserverX11 {
+ public:
+  GlobalMenuBarX11(views::DesktopWindowTreeHostX11* host, ui::MenuModel* model);
+  ~GlobalMenuBarX11() override;
+
+  // Creates the object path for DbusemenuServer which is attached to |xid|.
+  static std::string GetPathForWindow(unsigned long xid);
+  static bool IsGlobalMenuBarEnabled();
+
+  // Overridden from views::DesktopWindowTreeHostObserverX11:
+  void OnWindowMapped(unsigned long xid) override;
+  void OnWindowUnmapped(unsigned long xid) override;
+
+ private:
+
+  // Builds a separator.
+  DbusmenuMenuitem* BuildSeparator();
+
+  // Creates an individual menu item from a title and command, and subscribes
+  // to the activation signal.
+  DbusmenuMenuitem* BuildMenuItem(const std::string& label, int tag_id);
+
+  // Creates a DbusmenuServer, and attaches all the menu items.
+  void InitServer(unsigned long xid);
+
+  // Creates a whole menu defined with |model|
+  DbusmenuMenuitem* BuildStaticMenuFromModel(DbusmenuMenuitem* parent, ui::MenuModel* model);
+
+  // Sets the accelerator for |item|.
+  void RegisterAccelerator(DbusmenuMenuitem* item,
+                           const ui::Accelerator& accelerator);
+
+  // This will remove all menu items in |menu|.
+  void ClearMenuSection(DbusmenuMenuitem* menu);
+
+  CHROMEG_CALLBACK_1(GlobalMenuBarX11, void, OnItemActivated, DbusmenuMenuitem*,
+                     unsigned int);
+  CHROMEG_CALLBACK_0(GlobalMenuBarX11, void, OnSubMenuShow, DbusmenuMenuitem*);
+
+  views::DesktopWindowTreeHostX11* host_;
+
+  DbusmenuServer* server_;
+  DbusmenuMenuitem* root_item_;
+
+  ui::MenuModel* model_;
+
+  // For callbacks may be run after destruction.
+  base::WeakPtrFactory<GlobalMenuBarX11> weak_ptr_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(GlobalMenuBarX11);
+};
+
+} // namspace nw
+#endif  // CONTENT_NW_SRC_BROWSER_GLOBAL_MENU_BAR_X11_H_


### PR DESCRIPTION
Global menubar is implemented via dbus API. And it will fallback
to local menubar when no global menubar available.

fixed #2718
