### PR TITLE
fix id allocation for tray

### DIFF
--- a/src/resources/api_nw_tray.js
+++ b/src/resources/api_nw_tray.js
@@ -2,7 +2,6 @@ var Binding = require('binding').Binding;
 var forEach = require('utils').forEach;
 var nwNative = requireNative('nw_natives');
 var sendRequest = require('sendRequest');
-var contextMenuNatives = requireNative('context_menus');
 var messagingNatives = requireNative('messaging_natives');
 var Event = require('event_bindings').Event;
 var util = nw.require('util');
@@ -72,7 +71,7 @@ function Tray(option) {
     option.menu = option.menu.id;
   }
   
-  var id = contextMenuNatives.GetNextContextMenuId();
+  var id = nw.Obj.allocateId();
   this.id = id;
   privates(this).option = option;
 

--- a/test/sanity/issue5202-tray-menu-id/index.html
+++ b/test/sanity/issue5202-tray-menu-id/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>issue-5202-tray-menu-id</title>
+</head>
+<body>
+  
+  <script>
+  function out(id, msg) {
+    var h1 = document.createElement('h1');
+    h1.setAttribute('id', id);
+    h1.innerHTML = msg;
+    document.body.appendChild(h1);
+  }
+  
+  var tray = new nw.Tray({title: 'my-tray'});
+  var menu = new nw.Menu();
+  var menuitem = new nw.MenuItem({label: 'my-item'});
+
+  out('result', (tray.id !== menu.id && tray.id !== menuitem.id && menu.id !== menuitem.id) ? 'success': `failed: tray.id=${tray.id} menu.id=${menu.id} menuitem.id=${menuitem.id}`);
+  </script>
+</body>
+</html>

--- a/test/sanity/issue5202-tray-menu-id/package.json
+++ b/test/sanity/issue5202-tray-menu-id/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue5202-tray-menu-id",
+  "main": "index.html"
+}

--- a/test/sanity/issue5202-tray-menu-id/test.py
+++ b/test/sanity/issue5202-tray-menu-id/test.py
@@ -1,0 +1,21 @@
+import time
+import os
+import platform
+import sys
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options)
+driver.implicitly_wait(10)
+time.sleep(1)
+try:
+    print driver.current_url
+    result = driver.find_element_by_id('result').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+finally:
+    driver.quit()


### PR DESCRIPTION
Previous change in 4b9e319 used id allocated from `nw.Obj` instead
of from `context_menus` for `nw.Menu` and `nw.MenuItem`. But `nw.Tray`
was still using the old way, which generated conflicted id.

fixed #5202