### PR TITLE
[mac] added base_mac.mm & base_mac.h to mac build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -160,6 +160,8 @@ static_library("nw_browser") {
   }
   if (is_mac) {
     sources += [
+            "src/api/base/base_mac.h",
+            "src/api/base/base_mac.mm",
             "src/api/nw_window_api_mac.mm",
             "src/api/nw_menu_api_mac.mm",
             "src/api/menuitem/menuitem_mac.mm",

--- a/src/api/base/base_mac.mm
+++ b/src/api/base/base_mac.mm
@@ -38,16 +38,4 @@
   return wrapper == nil ? nil : [wrapper obj];
 }
 
-// - (void)setAssociatedCppObject:(void*)obj {
-//   [self setAssociatedObject: [CppWrapper createFromCppObject:obj]];
-// }
-
-// - (void*)associatedCppObject {
-//   id obj = [self associatedObject];
-//   if ([obj isKindOfClass: [CppWrapper class]]) {
-//     return [(CppWrapper*)obj obj];
-//   }
-//   return nullptr;
-// }
-
 @end

--- a/test/sanity/issue5229-menubar-crash/index.html
+++ b/test/sanity/issue5229-menubar-crash/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>menubar creation crash</title>
+</head>
+<body>
+  <script>
+  function out(id, msg) {
+    var h1 = document.createElement('h1');
+    h1.setAttribute('id', id);
+    h1.innerHTML = msg;
+    document.body.appendChild(h1);
+  }
+  var menu = new nw.Menu({type: 'menubar'});
+  out('result', 'success');
+  </script>
+</body>
+</html>

--- a/test/sanity/issue5229-menubar-crash/package.json
+++ b/test/sanity/issue5229-menubar-crash/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue5229-menubar-crash",
+  "main": "index.html"
+}

--- a/test/sanity/issue5229-menubar-crash/test.py
+++ b/test/sanity/issue5229-menubar-crash/test.py
@@ -1,0 +1,20 @@
+import time
+import os
+import platform
+import sys
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+chrome_options = Options()
+chrome_options.add_argument("nwapp=" + os.path.dirname(os.path.abspath(__file__)))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options)
+driver.implicitly_wait(2)
+time.sleep(1)
+try:
+    print driver.current_url
+    result = driver.find_element_by_id('result').get_attribute('innerHTML')
+    print result
+    assert('success' in result)
+finally:
+    driver.quit()


### PR DESCRIPTION
These two files provided util APIs for storing & retrieving NW menu
objects within `NSMenu`. Added them for GN build to prevent crashes
when creating menubar on Mac.

* test case: test/sanity/issue5229-menubar-crash
* fixed #5229