### PR TITLE
updated test case & hooks for `open` event of `nw.App`

### DIFF
--- a/src/browser/nw_chrome_browser_hooks.cc
+++ b/src/browser/nw_chrome_browser_hooks.cc
@@ -370,11 +370,7 @@ bool ProcessSingletonNotificationCallbackHook(const base::CommandLine& command_l
   bool single_instance = true;
   package->root()->GetBoolean(switches::kmSingleInstance, &single_instance);
   if (single_instance) {
-#if defined(OS_WIN)
-    std::string cmd = base::UTF16ToUTF8(command_line.GetCommandLineString());
-#else
-    std::string cmd = command_line.GetCommandLineString();
-#endif
+    auto cmd = command_line.GetCommandLineString();
     std::unique_ptr<base::ListValue> arguments(new base::ListValue());
     arguments->AppendString(cmd);
     SendEventToApp("nw.App.onOpen", std::move(arguments));

--- a/test/sanity/app-open-event/index.html
+++ b/test/sanity/app-open-event/index.html
@@ -5,11 +5,13 @@
     <title>App.open event test</title>
   </head>
   <body>
-    <h1 id='result'>App.open event test</h1>
     <script type="text/javascript">
       nw.App.on('open', function(cmd){
-            document.getElementById('result').innerHTML = cmd;
-        });
+        var h1 = document.createElement('h1');
+        h1.setAttribute('id', 'result');
+        h1.innerHTML = cmd;
+        document.body.appendChild(h1);
+      });
     </script>
   </body>
 </html>

--- a/test/sanity/app-open-event/test.py
+++ b/test/sanity/app-open-event/test.py
@@ -17,10 +17,10 @@ time.sleep(1)
 try:
     print driver.current_url
     second_instance = subprocess.Popen(['python', 'second_instance.py'])
-    time.sleep(2)
-    result = driver.find_element_by_id('result')
-    print result.get_attribute('innerHTML')
-    assert("success" in result.get_attribute('innerHTML'))
+    second_instance.wait()
+    result = driver.find_element_by_id('result').get_attribute('innerHTML')
+    print result
+    assert("success" in result)
+    assert("--flag-switches-begin" not in result)
 finally:
     driver.quit()
-    #second_instance.kill()


### PR DESCRIPTION
test case: test/sanity/app-open-event
issue: #2068
