### PR TITLE
updated test cases for nw18 update

### DIFF
--- a/test/sanity/issue3780-jailed-elements/test.py
+++ b/test/sanity/issue3780-jailed-elements/test.py
@@ -23,7 +23,7 @@ try:
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
     print 'click Elements panel'
-    driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-elements")').click()
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-elements")').click()
     print 'find h1'
     h1 = driver.execute_script('return document.getElementById("elements-content").firstChild.shadowRoot.querySelectorAll(".webkit-html-text-node")[1]').get_attribute('textContent')
     print h1

--- a/test/sanity/issue3780-jailed/test.py
+++ b/test/sanity/issue3780-jailed/test.py
@@ -23,7 +23,7 @@ try:
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
     print 'click Console panel'
-    driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
     print 'send_keys "location.pathname<enter>"'
     driver.find_element_by_id('console-prompt').send_keys('location.pathname\n')
     pathname = driver.find_element_by_css_selector('.console-user-command-result .console-message-text .object-value-string').get_attribute('textContent')

--- a/test/sanity/issue3835-inspect-crash/test.py
+++ b/test/sanity/issue3835-inspect-crash/test.py
@@ -20,7 +20,7 @@ try:
     print driver.window_handles
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
-    driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
     driver.find_element_by_id('console-prompt').send_keys('chrome\n')
     driver.find_element_by_class_name('console-object-preview').click()
     time.sleep(1) # wait for crash!

--- a/test/sanity/issue4121-inpect-node-crash/test.py
+++ b/test/sanity/issue4121-inpect-node-crash/test.py
@@ -20,7 +20,7 @@ try:
     wait_window_handles(driver, 2)
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
-    driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
     driver.find_element_by_class_name('console-message-url').click()
     sources_panel = driver.find_element_by_css_selector('.panel.sources')
     assert(sources_panel is not None)

--- a/test/sanity/issue4269-click-link-crash/test.py
+++ b/test/sanity/issue4269-click-link-crash/test.py
@@ -36,7 +36,7 @@ try:
     print driver.window_handles
     print 'switch to devtools window'
     switch_to_devtools(driver, devtools_window=driver.window_handles[1]) # devtools comes to the 2nd
-    driver.execute_script('return document.querySelector(".inspector-view-tabbed-pane").shadowRoot.getElementById("tab-console")').click()
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
     driver.find_element_by_css_selector('.console-message-text .webkit-html-external-link').click()
     wait_window_handles(driver, 4)
     driver.switch_to_window(driver.window_handles[3])


### PR DESCRIPTION
Following test cases are affected by devtools update during nw18
update:
* issue3780-jailed-elements
* issue3780-jailed
* issue3835-inspect-crash
* issue4121-inpect-node-crash
* issue4269-click-link-crash

fixed #5273 #5274 #5275 #5276