### PR TITLE
[doc] updated known issues

### DIFF
--- a/docs/For Users/Migration/From 0.12 to 0.13.md
+++ b/docs/For Users/Migration/From 0.12 to 0.13.md
@@ -58,11 +58,10 @@
 
 ### Known issues
 
-+ The following window options passed to nw.Window.open() is not effective on Linux: `min_width`, `min_height`, `max_width`, `max_height`, `resizable` for now; try to set them in the callback.
-+ `nw.Window.get(window_object)` is not working as expected when passing the argument; use `window_object.nw.Window.get()` as a workaround.
-+ `nw.Window.reloadDev()` is not supported for now
++ The following window options passed to `nw.Window.open()` is not effective on **Linux**: `resizable` for now; try to set them in the callback.
++ `reloadDev()` and `isDevToolsOpen()` of `nw.Window` are not supported for now
 + `closed` event of `nw.Window`: `App.quit()` doesn't trigger this event.
-+ `devtools-closed` event of nw.Window is not supported for now.
++ `devtools-closed` event of `nw.Window` is not supported for now.
 + `as_desktop` option is not supported for now
 + `webkit.{plugin|java|page-cache}` option in `package.json` is not supported for now: plugins are enabled by default.
 + `nwUserAgent` attribute of `<iframe>` is not supported for now.


### PR DESCRIPTION
* `nw.Window.get(winObj)` is now supported. So it's removed from
list.
* min/max width/height options are working on Linux. Only resizable
is not working now due to upstream issues.
* added `isDevToolsOpen` as not supported