### PR TITLE
Fixed `ConvertToAbsolutePath` to return a absolute path

### DIFF
--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -235,7 +235,7 @@ FilePath Package::ConvertToAbsoutePath(const FilePath& path) {
   if (path.IsAbsolute())
     return path;
 
-  return this->path().Append(path);
+  return MakeAbsoluteFilePath(this->path()).Append(path);
 }
 
 GURL Package::GetStartupURL() {


### PR DESCRIPTION
When starting apps from a folder of parent, such as `nw ../app_root/`,
icon file cannot be loaded correctly. The root cause is that
`base::ReadFileToString` refused for path referencing to parent
folder. However path of icon obtained by `nw::Package::ConvertToAbsolutePath`
is still a relative path.
The patch fixes `ConvertToAbsolutePath` to return a absolute path.

fixed #5402
