### PR TITLE
[test] use ActionChains send keys to element avoid webdriver issues

### DIFF
--- a/test/sanity/issue3780-jailed/test.py
+++ b/test/sanity/issue3780-jailed/test.py
@@ -23,9 +23,9 @@ try:
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
     print 'click Console panel'
-    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
+    devtools_click_tab(driver, 'console')
     print 'send_keys "location.pathname<enter>"'
-    driver.find_element_by_id('console-prompt').send_keys('location.pathname\n')
+    devtools_type_in_console(driver, 'location.pathname\n')
     pathname = driver.find_element_by_css_selector('.console-user-command-result .console-message-text .object-value-string').get_attribute('textContent')
     print pathname
     assert (pathname == '/child.html')

--- a/test/sanity/issue3835-inspect-crash/test.py
+++ b/test/sanity/issue3835-inspect-crash/test.py
@@ -20,8 +20,10 @@ try:
     print driver.window_handles
     print 'switch to devtools'
     switch_to_devtools(driver, devtools_window=driver.window_handles[-1])
-    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-console")').click()
-    driver.find_element_by_id('console-prompt').send_keys('chrome\n')
+    print 'click Console panel'
+    devtools_click_tab(driver, 'console')
+    print 'send_keys "chrome<enter>"'
+    devtools_type_in_console(driver, 'chrome\n')
     driver.find_element_by_class_name('console-object-preview').click()
     time.sleep(1) # wait for crash!
     expanded = driver.find_element_by_css_selector('.console-view-object-properties-section.expanded')

--- a/test/sanity/nw_util.py
+++ b/test/sanity/nw_util.py
@@ -2,6 +2,7 @@ import time
 import platform
 import subprocess
 import selenium
+from selenium.webdriver.common.action_chains import ActionChains
 
 # wait for window handles
 def wait_window_handles(driver, until, timeout=60):
@@ -40,6 +41,13 @@ def switch_to_devtools(driver, devtools_window=None):
     # wait for devtools is completely loaded
     while driver.execute_script('return document.readyState') != 'complete':
         time.sleep(1)
+
+def devtools_click_tab(driver, tab_name):
+    driver.execute_script('return document.querySelector(".tabbed-pane").shadowRoot.getElementById("tab-%s")' % tab_name).click()
+
+def devtools_type_in_console(driver, keys):
+    console_prompt = driver.find_element_by_id('console-prompt')
+    ActionChains(driver).click(console_prompt).send_keys(keys).perform()
 
 def no_live_process(driver, print_if_fail=True):
     if platform.system() == 'Windows':


### PR DESCRIPTION
`driver.find_element_by_id().send_keys()` will cause an error of
"cannot focus element". This happens for typing into inputs of console
of DevTools, which is using CodeMirror. Use `ActionChains(driver).send_keys()`
can workaround this issue.

Fixed test cases:

* issue3780-jailed
* issue3835-inspect-crash