### PR TITLE
[doc] updated docs for rebuilding native modules

### DIFF
--- a/docs/For Users/Advanced/Use Native Node Modules.md
+++ b/docs/For Users/Advanced/Use Native Node Modules.md
@@ -3,7 +3,12 @@
 
 [TOC]
 
-## For LTS Releases
+## Install with NPM
+
+### For LTS Releases
+
+!!! warning "Use Same Version and Architecture of Node.js and NW.js"
+    Following instructions only works if you are using the same version and architecture of Node.js and NW.js.
 
 If you are using LTS release, native modules installed by `npm` can be supported after hacking as below:
 
@@ -11,15 +16,47 @@ If you are using LTS release, native modules installed by `npm` can be supported
 * On Windows, you need to replace the file
 `<npm-path>\node_modules\node-gyp\src\win_delay_load_hook.cc` with the one at https://github.com/nwjs/nw.js/blob/nw18/tools/win_delay_load_hook.cc before installing modules with node-gyp or npm.
 
-## For non-LTS Releases
+### For non-LTS Releases
 
-If you are using non-LTS release, you have to rebuild the modules with one of following tools due to [ABI differences in V8](https://github.com/nwjs/nw.js/issues/5025).
+If you are using non-LTS release, `nw-gyp` is required to be pre-installed globally to build modules due to [ABI differences in V8](https://github.com/nwjs/nw.js/issues/5025). These instructions below works for LTS releases as well.
+
+To install native modules for NW.js, run following commands in your terminal:
+
+```bash
+# Install nw-gyp globally
+npm install -g nw-gyp
+# Setup target NW.js version
+export npm_config_target=0.18.5
+# Setup build architecture, ia32 or x64
+export npm_config_arch=x64
+export npm_config_target_arch=x64
+# Setup env for modules built with node-pre-gyp
+export npm_config_runtime=node-webkit
+export npm_config_build_from_source=true
+# Setup nw-gyp as node-gyp
+export npm_config_node_gyp=$(which nw-gyp)
+# Run npm install
+npm install
+```
+
+!!! warning "Note for Windows"
+    On Windows, `npm_config_node_gyp` have to be set to `path\to\global\node_modules\nw-gyp\bin\nw-gyp.js` instead of its batch script `nw-gyp.cmd`. This should be a [bug of npm](https://github.com/npm/npm/issues/14543).
+
+## Manually Rebuild
+
+!!! tip "Full NPM Install is Recommended"
+    After a version switch of NW.js, the recommended approach is to delete `node_modules` folder and do a full npm install as [the instructions above](#install-with-npm).
+
+Once you switch to a new version of NW.js, you can rebuild **each** of the native modules with the tools below **without reinstall all the modules**. Since `binding.gyp` is required for building native modules, you can easily locate all native modules by finding `binding.gyp` file.
+
+!!! warning "Rebuild ALL Native Modules"
+    Make sure you **rebuilt all native modules**. Or you will meet various issues, even crashes. Once manually rebuild don't work for you, try to do a full npm install.
 
 ### nw-gyp
 
-[`nw-gyp`](https://github.com/nwjs/nw-gyp) is a hack on `node-gyp` to support NW.js specific headers and libraries. 
+[`nw-gyp`](https://github.com/nwjs/nw-gyp) is a hack on `node-gyp` to support NW.js specific headers and libraries.
 
-The usage is the same with `node-gyp`, except that you need to specify the version and arch (`x64` or `ia32`) of NW.js manually. 
+The usage is the same with `node-gyp`, except that you need to specify the version and arch (`x64` or `ia32`) of NW.js manually.
 
 ````bash
 npm install -g nw-gyp
@@ -34,6 +71,7 @@ See https://github.com/nwjs/nw-gyp for more details.
 Some packages uses [node-pre-gyp](https://github.com/mapbox/node-pre-gyp), which supports building for both Node.js and NW.js by using either `node-gyp` or `nw-gyp`.
 
 The usage of `node-pre-gyp` is as following:
+
 ````bash
 npm install -g node-pre-gyp
 cd myaddon
@@ -41,8 +79,4 @@ node-pre-gyp build --runtime=node-webkit --target=0.13.0 --target_arch=x64
 ````
 
 See https://github.com/mapbox/node-pre-gyp for more details.
-
-### Known Issues
-
-So far, you have to rebuild **each native module** with tools above including thoses are indirectly depended modules. Since `binding.gyp` is required for building native modules, you can easily locate all native modules by finding `binding.gyp` file.
 


### PR DESCRIPTION
Use `npm_config_` environments to override default behaviors of
npm and node-gyp. `npm_config_node_gyp` can be used to replace
`node-gyp` with `nw-gyp` during `npm install`.