### PR TITLE
App.open event should be fired with `single-instance` set to `false`

### DIFF
--- a/src/browser/nw_chrome_browser_hooks.cc
+++ b/src/browser/nw_chrome_browser_hooks.cc
@@ -366,21 +366,12 @@ void MainPartsPreMainMessageLoopRunHook() {
 
 bool ProcessSingletonNotificationCallbackHook(const base::CommandLine& command_line,
                                               const base::FilePath& current_directory) {
-  nw::Package* package = nw::package();
-  bool single_instance = true;
-  package->root()->GetBoolean(switches::kmSingleInstance, &single_instance);
-  if (single_instance) {
-#if defined(OS_WIN)
-    std::string cmd = base::UTF16ToUTF8(command_line.GetCommandLineString());
-#else
-    std::string cmd = command_line.GetCommandLineString();
-#endif
-    std::unique_ptr<base::ListValue> arguments(new base::ListValue());
-    arguments->AppendString(cmd);
-    SendEventToApp("nw.App.onOpen", std::move(arguments));
-  }
+  auto cmd = base::UTF16ToUTF8(command_line.GetCommandLineString());
+  std::unique_ptr<base::ListValue> arguments(new base::ListValue());
+  arguments->AppendString(cmd);
+  SendEventToApp("nw.App.onOpen", std::move(arguments));
     
-  return single_instance;
+  return true;
 }
 
 } // namespace nw

--- a/test/sanity/issue5354-app-open-single-instance/index.html
+++ b/test/sanity/issue5354-app-open-single-instance/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8">
+    <title>App.open event test </title>
+  </head>
+  <body>
+    <h1 id='result'>App.open event test</h1>
+    <script type="text/javascript">
+      nw.App.on('open', function(cmd){
+        document.getElementById('result').innerHTML = cmd;
+      });
+    </script>
+  </body>
+</html>
+    

--- a/test/sanity/issue5354-app-open-single-instance/package.json
+++ b/test/sanity/issue5354-app-open-single-instance/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "issue5354-deprecate-single-instance",
+  "main": "index.html",
+  "single-instance": false
+}

--- a/test/sanity/issue5354-app-open-single-instance/second_instance.py
+++ b/test/sanity/issue5354-app-open-single-instance/second_instance.py
@@ -1,0 +1,19 @@
+import time
+import os
+import subprocess
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+chrome_options = Options()
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+chrome_options.add_argument("nwapp=" + testdir)
+chrome_options.add_argument("user-data-dir=" + os.path.join(testdir, 'userdata'))
+chrome_options.add_nw_argument("success")
+
+try:
+    driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log2", service_args=["--verbose", "--launch-timeout=5"])
+except:
+    pass
+
+

--- a/test/sanity/issue5354-app-open-single-instance/test.py
+++ b/test/sanity/issue5354-app-open-single-instance/test.py
@@ -1,0 +1,26 @@
+import time
+import os
+import subprocess
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+chrome_options = Options()
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(testdir)
+
+chrome_options.add_argument("nwapp=" + testdir)
+chrome_options.add_argument("user-data-dir=" + os.path.join(testdir, 'userdata'))
+
+driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])
+time.sleep(1)
+try:
+    print driver.current_url
+    second_instance = subprocess.Popen(['python', 'second_instance.py'])
+    time.sleep(2)
+    result = driver.find_element_by_id('result')
+    print result.get_attribute('innerHTML')
+    assert("success" in result.get_attribute('innerHTML'))
+finally:
+    driver.quit()
+    #second_instance.kill()

--- a/test/sanity/issue5354-app-open-single-instance/userdata/keep
+++ b/test/sanity/issue5354-app-open-single-instance/userdata/keep
@@ -1,0 +1,1 @@
+keep this dir


### PR DESCRIPTION
`single-instance` was deprecated in nw13 and always assumes to be
`true`.

test: issue5354-app-open-single-instance
fixed #5354