### PR TITLE
fixed `show_in_taskbar` option for `nw.Window.open`

### DIFF
--- a/src/api/nw_window.idl
+++ b/src/api/nw_window.idl
@@ -34,6 +34,7 @@ namespace nw.Window {
     [nodoc] boolean? kiosk;
     [nodoc] boolean? focus;
     [nodoc] boolean? new_instance;
+    [nodoc] boolean? show_in_taskbar;
     [nodoc] DOMString? title;
     [nodoc] DOMString? position;
     [nodoc] DOMString? icon;


### PR DESCRIPTION
fixed #4970 
backport from #5452