### PR TITLE
fix keyboard access for menus

### DIFF
--- a/src/api/menuitem/menuitem.h
+++ b/src/api/menuitem/menuitem.h
@@ -41,6 +41,7 @@ class MenuItemDelegate;
 #include "base/strings/string16.h"
 #include "ui/gfx/image/image.h"
 #include "ui/base/accelerators/accelerator.h"
+#include "ui/views/controls/button/menu_button.h"
 #include "ui/views/focus/focus_manager.h"
 #endif  // defined(OS_MACOSX)
 
@@ -79,6 +80,7 @@ class MenuItem : public Base {
    bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
    bool CanHandleAccelerators() const override;
   void UpdateKeys(views::FocusManager *focus_manager);
+  void SetMenuBarButton(views::MenuButton* menubar_button);
 #endif
 
   void OnClick();
@@ -120,6 +122,9 @@ class MenuItem : public Base {
   views::FocusManager *focus_manager_;
 
   ui::Accelerator accelerator_;
+  ui::Accelerator accelerator_mnemonic_;
+
+  views::MenuButton* menubar_button_;
 
   // Flag to indicate we need refresh.
   bool is_modified_;
@@ -133,6 +138,7 @@ class MenuItem : public Base {
   base::string16 tooltip_;
   Menu* submenu_;
   bool enable_shortcut_;
+  bool enable_mnemonic_;
 
   bool meta_down_flag_;
 

--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -373,7 +373,7 @@ bool NwCurrentWindowInternalSetMenuFunction::RunNWSync(base::ListValue* response
   MenuBarView* menubar = new MenuBarView();
   static_cast<BrowserViewLayout*>(native_app_window_views->GetLayoutManager())->set_menu_bar(menubar);
   native_app_window_views->AddChildView(menubar);
-  menubar->UpdateMenu(menu->model());
+  menubar->UpdateMenu(menu);
   native_app_window_views->layout_();
   native_app_window_views->SchedulePaint();
   menu->UpdateKeys( native_app_window_views->widget()->GetFocusManager() );

--- a/src/browser/menubar_controller.cc
+++ b/src/browser/menubar_controller.cc
@@ -43,7 +43,7 @@ views::MenuItemView* MenuBarController::GetSiblingMenu(
   if (!menubar_->GetMenuButtonAtLocation(menubar_loc, &model, button))
     return NULL;
 
-  *has_mnemonics = false;
+  *has_mnemonics = true;
   *anchor = views::MENU_ANCHOR_TOPLEFT;
   master_->active_menu_model_ = model;
   if (!model_to_menu_map_[model]) {

--- a/src/browser/menubar_view.h
+++ b/src/browser/menubar_view.h
@@ -21,6 +21,8 @@ namespace ui {
 
 namespace nw {
 
+class Menu;
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 //  copied from chrome/browser/ui/views/bookmarks/bookmark_bar_view.h
@@ -43,8 +45,8 @@ class MenuBarView :
   MenuBarView();
   ~MenuBarView() override;
 
-  void UpdateMenu(ui::MenuModel* model);
-  void InitView(ui::MenuModel* model);
+  void UpdateMenu(Menu* menu);
+  void InitView(Menu* menu);
 
   bool GetMenuButtonAtLocation(const gfx::Point& loc, ui::MenuModel** model, views::MenuButton** button);
 


### PR DESCRIPTION
* support showing menus when accelerator pressed
* support mnemonic (i.e. `&File` rendered as File with shortcut
`Alt+F`)

fixed #4943