### PR TITLE
[doc] updated documentation for building NW.js

### DIFF
--- a/docs/For Developers/Building NW.js.md
+++ b/docs/For Developers/Building NW.js.md
@@ -4,7 +4,6 @@
 [TOC]
 
 !!! important
-    Starting from 0.17, we switched to the new build configuration system GN and Ninja in Chromium upstream. The Node.js in NW is still build with GYP/Ninja
     This document is written for latest **NW 0.13** or later. For legacy build instructions, please read the [wiki page](https://github.com/nwjs/nw.js/wiki/Building-nw.js) on GitHub.
     See our buildbot for official build configuration and steps: http://buildbot-master.nwjs.io:8010/waterfall
     Debug version should be built with component build configuration. See the [discussion in upstream](https://groups.google.com/a/chromium.org/d/msg/chromium-dev/LWRR3fMlvQ4/qos4EaBtBgAJ).
@@ -20,9 +19,6 @@ NW.js use same build tools and similar steps as Chromium. Read the instructions 
 !!! note "Windows"
     As suggested by Chromium document, you need to run `set DEPOT_TOOLS_WIN_TOOLCHAIN=0` or set the variable in your global environment.
 
-!!! note "Xcode 7"
-    Mac SDK 10.11 as part of Xcode 7 is not supported yet. If you have upgraded to Xcode 7, either downgrade to Xcode 6 or copy Mac SDK 10.10 from other machines under ```xcode-select -p`/Platforms/MacOSX.platform/Developer/SDKs`` as suggested by [Chromium document](https://chromium.googlesource.com/chromium/src/+/master/docs/mac_build_instructions.md).
-
 ## Get the Code
 
 **Step 1.** Create a folder for holding NW.js source code, like `$HOME/nwjs`, and run following command in the folder to generate `.gclient` file:
@@ -30,7 +26,7 @@ NW.js use same build tools and similar steps as Chromium. Read the instructions 
 ```bash
 mkdir -p $HOME/nwjs
 cd $HOME/nwjs
-gclient config --name=src https://github.com/nwjs/chromium.src.git@origin/nw17
+gclient config --name=src https://github.com/nwjs/chromium.src.git@origin/nw19
 ```
 
 Generally if you are not interested in running Chromium tests, you don't have to sync the test cases and reference builds, which saves you lot of time. Open the `.gclient` file you just created and replace `custom_deps` section with followings:
@@ -47,7 +43,7 @@ Generally if you are not interested in running Chromium tests, you don't have to
 }
 ```
 
-Manually clone and checkout correct branches for following repositories:
+**Step2.** Manually clone and checkout correct branches for following repositories:
 
 | path | repo |
 |:---- |:---- |
@@ -55,8 +51,8 @@ Manually clone and checkout correct branches for following repositories:
 | src/third_party/node | https://github.com/nwjs/node |
 | src/v8 | https://github.com/nwjs/v8 |
 
-**Step 2.** Run following command in your terminal:
-```
+**Step 3.** Syncing full source code with following command:
+```bash
 gclient sync --with_branch_heads
 ```
 
@@ -65,82 +61,111 @@ This usually downloads 20G+ from GitHub and Google's Git repos. Make sure you ha
 When finished, you will see a `src` folder created in the same folder as `.gclient`.
 
 !!! note "First Build on Linux"
-    If you are building on Linux **for the first time**, you need to run `gclient sync --with_branch_heads --nohooks` and then run `./build/install-build-deps.sh` to install dependencies on Ubuntu. See [Chromium document](http://dev.chromium.org/developers/how-tos/get-the-code) for detailed instructions of getting the source code.
+    If you are building on Linux **for the first time**, you need to do this in 3 steps:
 
-## Generate ninja build files with GN for Chromium
+    * `gclient sync --with_branch_heads --nohooks`
+    * `./build/install-build-deps.sh` to install dependencies on Ubuntu
+    * `gclient runhooks` to download common dependencies
 
-```bash
-cd src
-gn gen out/nw  (changing the 'nw' part of the path is not supported. You'd better not changing the 'out' part if you're new to this)
-```
+## Generate build files
 
-Use flags like our official build:
+Chromium has shifted from [`gyp`](https://gyp.gsrc.io/) to [`gn`](https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/quick_start.md) to generate build files. But Node.js is still based on `gyp`. So you have to generate build files for both of them.
+
+### Generate ninja build files with GN for Chromium
+
+Run `gn args out/nw` in `src` folder and it will open an editor for you to input build arguments. Typically you can type in following build arguments for **non-debugable** **64-bit** **normal build** NW.js with **ffmpeg built as dynamic library**:
+
 ````
 is_debug=false
 is_component_ffmpeg=true
 target_cpu="x64"
+nwjs_sdk=false
 ````
-We support component build: `is_component_build = true` for faster development cycle. It should be used when you are trying to build debug version.
 
-See the upstream documentation for the mapping between GN and GYP flags: https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/cookbook.md#Variable-mappings
+Then it will generate ninja build files in `out/nw`. You can re-run `gn args out/nw` to edit the arguments later.
 
-## Generate ninja build files with GYP for Node
+Here are some useful GN arguments:
+
+* `nwjs_sdk` (`bool`): build NW.js SDK flavor with DevTools enabled
+* `is_debug` (`bool`): build in debug mode with debugable symbols and no optimization
+* `is_component_build` (`bool`): link binaries into separate dynamic libraries. This will speed up the build in debug mode.
+* `enable_nacl` (`bool`): enable NaCl
+* `target_cpu` (`string`): "x64" and "x86" for 64-bit and 32-bit binaries
+* `is_official_build` (`bool`): enable more optimizations for official release
+* `is_component_ffmpeg` (`bool`): build ffmpeg as dynamic library
+
+See Google's [GN build configuration](https://www.chromium.org/developers/gn-build-configuration) for more details.
+
+### Generate ninja build files with GYP for Node
+
+Run following scripts in `src` folder:
 
 ```bash
-cd src
-GYP_CHROMIUM_NO_ACTION=0 ./build/gyp_chromium -I third_party/node/common.gypi third_party/node/node.gyp
+export GYP_DEFINES="target_arch=x64"
+./build/gyp_chromium -I third_party/node/common.gypi third_party/node/node.gyp
 ```
 
-or use the following if you're doing a component build:
-```bash
-./build/gyp_chromium -D component=shared_library -I third_party/node/common.gypi third_party/node/node.gyp
-```
-To change the build configuration for Node, you need to setup the GYP_DEFINES environment variable:
+This will generate ninja build files in `out/Debug` and `out/Release` folders.
 
-### 32-bit/64-bit Build
+!!! note "Build Folders for 64-bit Binaries on Windows"
+    On Windows, build folders for 64-bit binaries are located in `out/Debug_x64` and `out/Release_x64`.
 
-* Windows
-    - 32-bit: is the default build target
-    - 64-bit: `set GYP_DEFINES="target_arch=x64"` and rebuild in `out/Debug_x64` or `out/Release_x64` folder
-* Linux
-    - 32-bit: **TODO: chroot**
-    - 64-bit: is the default build target
-* Mac
-    - 32-bit: `export GYP_DEFINES="host_arch=ia32 target_arch=ia32"` and rebuild in `out/Debug` or `out/Release` folder
-    - 64-bit: is the default build target
+Here are some useful GYP arguments set with `GYP_DEFINES` environment:
 
-## Build nwjs
+* `nwjs_sdk` (`bool`): set to 1 to build NW.js SDK flavor with DevTools enabled.
+* `target_arch` (`string`): "x64" and "ia32" for 64-bit and 32-bit binaries
+* `component` (`string`): set to "shared_library" to link binaries into separate dynamic libraries. This will speed up the build in debug mode.
+* `clang` (`bool`): set to 1 to enable building with `clang` toolchain. **This should be set to 0 on Windows**.
 
-ninja build files are generated in `out/nw` folder after you run GN. Run following command in your terminal will generate the Debug build of standard NW.js binaries in `out/nw` folder:
+## Build
+
+### Build nwjs
+
+Ninja build files are generated in `out/nw` folder after you run GN. Run following command in `src` folder will generate NW.js binaries in `out/nw` folder:
 
 ```bash
-cd src
 ninja -C out/nw nwjs
 ```
 
 !!! tip "Build Time"
     Generally a full build takes hours of time depending on the performance of your machine. Recommended configuration is to build on a PC with multicore CPU (>=8 cores), SSD and large memory (>= 8G). And you can read [Build Faster](#build-faster) section below for some tips to speed up the build.
 
-To build 32-bit/64-bit binaries or non-standard build flavors, you need to edit out/nw/args.gn file And then re-run the commands above to generate binaries.
+### Build Node
 
-## Build Node
+Build Node by running following scripts in `src` folder:
 
 ```bash
-cd src
 ninja -C out/Release node
 ```
 
-After building Node, the final step is to copy the build Node library to the nwjs binary folder:
+Then copy the build Node library to the nwjs binary folder:
 
 ```bash
-cd src
 ninja -C out/nw copy_node
 ```
 
+To switch between 32-bit/64-bit binaries or non-standard build flavors, you need to update `GYP_DEFINES` environment and [regenerate ninja files](#generate-build-files) and then re-run the commands above to generate binaries.
+
+### Generate NW.js Distribution Packages (Optional)
+
+Run following script sin `src` folder:
+
+```bash
+ninja -C out/nw dist
+```
+
+You will get NW.js packages in `out/nw/dist` including binaries, symbols and nw-gyp headers (generated on macOS only) and libraries (generated on Windows only).
+
+You can only generate packages with `is_debug=false`.
+
 ## Build Flavors
 
-* Standard: 'nwjs_sdk=false'
-* SDK: `enable_nacl=true`
+For different build flavors, you need to set corresponding arguments for GN and GYP as below:
+
+|     | GN | GYP |
+|:---:|:---|:---|
+| Normal | nwjs_sdk=false | nwjs_sdk=0 |
+| SDK | nwjs_sdk=true<br>enable_nacl=true | nwjs_sdk=1 |
 
 See [Build Flavors](../For Users/Advanced/Build Flavors.md) for the differences of all supported build flavors.
 
@@ -153,4 +178,5 @@ Due to the license issue, the prebuilt binaries of NW.js doesn't support proprie
 From Google's website, there are a few tips to speed up your build. Open the links below to see the tips for your platform:
 
 * [Mac Build Instructions: Faster builds](https://chromium.googlesource.com/chromium/src/+/master/docs/mac_build_instructions.md#Faster-builds)
-* [Tips for improving build speed on Linux](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_faster_builds.md)
+* [Linux Build Instructions: Faster builds](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#faster-builds)
+* [Windows Build Instructions: Faster builds](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#Faster-builds)

--- a/docs/For Developers/Enable Proprietary Codecs.md
+++ b/docs/For Developers/Enable Proprietary Codecs.md
@@ -65,14 +65,6 @@ python tools/clang/scripts/update.py --if-needed
 ```bash
 python build/linux/sysroot_scripts/install-sysroot.py --running-as-hook
 ```
-* **[Mac]** Download **libc++-static** library in `third_party/libc++-static` by
-```bash
-download_from_google_storage --no_resume \
-                             --platform=darwin \
-                             --no_auth \
-                             --bucket chromium-libcpp \
-                             -s third_party/libc++-static/libc++.a.sha1
-```
 
 !!! tip "For Linux Developers"
     Please run `build/install-build-deps.sh` for the first time building FFmpeg DLL or NW.js before proceeding to the instructions below. You only have to run it once. This script will install the build dependencies automatically for you.
@@ -82,12 +74,10 @@ download_from_google_storage --no_resume \
 Replace `BUILD.gn` in the root of the source code with following:
 
 ```
-action("dummy") {
+group("dummy") {
   deps = [
     "//third_party/ffmpeg"
   ]
-  script = "dummy"
-  outputs = ["$target_gen_dir/dummy.txt"]
 }
 ```
 


### PR DESCRIPTION
Updated followings for `Building NW.js.md`

* Clear out the build steps
   * merged GN/GYP into one step
   * merged build nwjs/Node into one step
* Added descriptions for GN/GYP arguments
* Added sections for `dist` target
* Removed outdated Xcode warnings
* Corrected external links for Build Faster section

Updated followings for `Enable Proprietary Codecs.md`

* Removed invalid step of downloading libc++
* Updated dummy BUILD.gn script

fixed #5555