### PR TITLE
[doc] avoiding two en dash become an em dash after mkdocs

### DIFF
--- a/docs/For Users/Debugging with DevTools.md
+++ b/docs/For Users/Debugging with DevTools.md
@@ -22,13 +22,13 @@ You can use the `--remote-debugging-port=port` command line option to specify wh
 
 ## Using devtools extensions
 
-Devtools extensions are fully supported, including the one for ReactJS etc. To use it, add the permission "chrome-extension://*" to manifest.json of the devtools extension, and load it with '--load-extension=path/to/extension' when nw is started. The files for devtools extensions can be copied from extension folder of Chrome browser after you install them from Chrome Web Store.
+Devtools extensions are fully supported, including the one for ReactJS etc. To use it, add the permission "chrome-extension://*" to manifest.json of the devtools extension, and load it with `--load-extension=path/to/extension` when nw is started. The files for devtools extensions can be copied from extension folder of Chrome browser after you install them from Chrome Web Store.
 
 ### Sample
 
 https://s3-us-west-2.amazonaws.com/nwjs/sample/react-app.zip
 https://s3-us-west-2.amazonaws.com/nwjs/sample/react-devtools.zip
 
-Unpack them, download the SDK build and run it with: nw.exe --load-extension=path/to/devtools path/to/app/folder
+Unpack them, download the SDK build and run it with: `nw.exe --load-extension=path/to/devtools path/to/app/folder`
 
 The app is a simple react app with 'package.json' added. The devtools files are from the Chrome browser's extension folder of official react devtools extension installed from Chrome Web store. Only the manifest file is modified to add the permission: "chrome-extension://*".


### PR DESCRIPTION
`--` will become `–` after mkdocs and mislead users , so adding ` `` ` to avoid this.