### PR TITLE
adding PR - for nw-autoupdater

### DIFF
--- a/docs/For Users/Advanced/Autoupdates.md
+++ b/docs/For Users/Advanced/Autoupdates.md
@@ -6,6 +6,7 @@
 NWJS tend to support the update solution made by community, not a built-in one. Below is the list of existing soutions, which worth checking.
 - [node-webkit-updater](https://github.com/edjafarov/node-webkit-updater) (by [@edjafarov](https://github.com/edjafarov))
 - [nwjs-autoupdater](https://github.com/oaleynik/nwjs-autoupdater) (by [@oaleynik](https://github.com/oaleynik))
+- [nw-autoupdater](https://github.com/dsheiko/nw-autoupdater) (by [@dsheiko](https://github.com/dsheiko))
 
 ## node-webkit-updater
 
@@ -22,7 +23,7 @@ You should build this logic by yourself though ([basic example](https://github.c
 
 ## nwjs-autoupdater
 
-The tiny golang application (when built it is just ~2MB), which can be bundled with NWJS application and then used to unpack updates. 
+The tiny golang application (when built it is just ~2MB), which can be bundled with NWJS application and then used to unpack updates.
 To update target application updater needs to know two things - where zip archive with the new version is located and where is the app's executable to restart application after update. These can be passed to updater via command line arguments `--bundle` and `--inst-dir`, where `--bundle` is the path to the zip archive with the new app version and `--inst-dir` is the path to app's executable.
 
 There are multiple advantages over `node-webkit-updater`:
@@ -32,3 +33,18 @@ There are multiple advantages over `node-webkit-updater`:
 - Updater's executalbe has way smaller size as it doesn't require bundling the whole new NWJS application with the main application.
 
 The logic to check for updates needs to be built on your own too. The [example](https://github.com/oaleynik/nwjs-autoupdater/blob/master/examples/index.js) shows the way how to use javascript module as an entry point for NWJS application and check for updates in background.
+
+## nw-autoupdater
+
+The NPM module provides API similar to one of `node-webkit-updater`, but extended, adapted for NW.js with Node 7.x and based on clean async/await syntax. Namely it allows to:
+- Read the manifest from the remote release server
+- Check if the version in the remote manifest greater than one of the local manifest
+- Download the latest available version matching the host platform (according to the `packages` map of the remote manifest)
+  - Subscribe for download progress events
+- Unpack it in a temporary directory (zip or tar.gz)
+  - Subscribe for install progress events
+- Close the app and launch it (as a detached process) from the downloaded release (from temporary directory)
+- Backup actual version and replace it with the new one
+- Restart the updated app from its original location
+
+The package includes examples of release server and client.


### PR DESCRIPTION
The documentation (http://docs.nwjs.io/en/latest/For%20Users/Advanced/Autoupdates/#autoupdates) recommends node-webkit-updater and nwjs-autoupdater.
 
As an alternative one can consider https://github.com/dsheiko/nw-autoupdater
It provides an API (like node-webkit-updater, but cleaner with use of async/await) to customize auto-update flow in one's app including download/install progress
 
Tested with NW.JS 0.21.3 on Ubuntu 16.04, macOS Sierra and Window 10
