### PR TITLE
[docs] replace nwjs-builder with nwjs-builder-phoenix

### DIFF
--- a/docs/For Users/Package and Distribute.md
+++ b/docs/For Users/Package and Distribute.md
@@ -9,7 +9,7 @@ This document guides you how to package and distribute NW.js based app.
 
 You can use following tools to automatically package your NW.js based app for distribution.
 
-* [nwjs-builder](https://github.com/evshiron/nwjs-builder)
+* [nwjs-builder-phoenix](https://github.com/evshiron/nwjs-builder-phoenix)
 * [nw-builder](https://github.com/nwjs/nw-builder)
 
 Or your can build your app manually with the instructions below.


### PR DESCRIPTION
Greetings.

I am the author of `nwjs-builder` and `nwjs-builder` was made in that particular period when `nw-builder` didn't support NW.js 0.13 and later.
Although there were some issues but `nwjs-builder` has already been working for months without being maintained.

Recently I found it difficult to fix issues in `nwjs-builder` and was shocked to discover the ecology difference between NW.js and Electron. I decided to rewrite a new builder tool for NW.js, inspired by `electron-builder`, as a total replacement to `nwjs-builder`, which I would drop support at any time.

Here comes `nwjs-builder-phoenix`. I am sorry to bring up a new package name but look, we have:

* a shining tool rewritten with TypeScript, with
  * simplified commands and configurations
  * concurrent building
  * powerful NSIS integration
  * and the lacking feature of packaging Chrome App without any changes

The current features should be able to replace `nwjs-builder`. The development is driven by my own projects' requirements, but I assume the common setup should work in most cases :)