### PR TITLE
Enable building NW.js when git index is not available.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -220,13 +220,22 @@ static_library("nw_renderer") {
 
 }
 
+nw_git_is_present = exec_script("tools/commit_id.py",
+                                [
+                                  "check",
+                                  rebase_path("../..", root_build_dir),
+                                ],
+                                "value")
+
+nw_use_commit_id = nw_git_is_present == 1
+
 config("commit_id_config") {
   include_dirs = [ "$root_gen_dir/nw" ]
 }
 
 commit_id_output_file = "$root_gen_dir/nw/id/commit.h"
-
-action("commit_id") {
+if (nw_use_commit_id) {
+  action("commit_id") {
     script = "tools/commit_id.py"
     inputs = [
        "//content/nw/.git/index",
@@ -245,6 +254,17 @@ action("commit_id") {
     ]
 
     public_configs = [ ":commit_id_config" ]
+  }
+} else {
+  copy("commit_id") {
+    sources = [
+      "src/commit.h",
+    ]
+    outputs = [
+      commit_id_output_file,
+    ]
+    public_configs = [ ":commit_id_config" ]
+  }
 }
 
 if (is_mac) {

--- a/src/commit.h
+++ b/src/commit.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Intel Corp
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell co
+// pies of the Software, and to permit persons to whom the Software is furnished
+//  to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in al
+// l copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNES
+// S FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WH
+// ETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// commit.h:
+//   This is a default commit hash header, when git is not available.
+//
+
+#define NW_COMMIT_HASH "unknown hash"
+#define NW_COMMIT_HASH_SIZE 12


### PR DESCRIPTION
It could be impractical for Linux distro packagers to fetch NW.js source
tree with gclient due to packaging infrastructure limitations, or create
their source packages with the huge git index in it. The change appeals
to them by imitating solutions in other Chromium components.