### PR TITLE
[Transparency][Win][OSX] use disable-gpu-compositing instead of disable-gpu

### DIFF
--- a/docs/For Users/Advanced/Transparent Window.md
+++ b/docs/For Users/Advanced/Transparent Window.md
@@ -39,7 +39,7 @@ You can enable transparency clickthrough on Windows and Mac. This feature enable
 
 To enable transparency clickthrough, you need following command line options:
 ```params
---disable-gpu --force-cpu-draw
+--disable-gpu-compositing --force-cpu-draw
 ```
 
 !!! note

--- a/src/browser/native_window.cc
+++ b/src/browser/native_window.cc
@@ -82,12 +82,6 @@ NativeWindow::NativeWindow(const base::WeakPtr<content::Shell>& shell,
   content::g_support_transparency = !base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kmDisableTransparency);
   if (content::g_support_transparency) {
     content::g_force_cpu_draw = base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kForceCpuDraw);
-    if (content::g_force_cpu_draw) {
-      if (!base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kDisableGpu)) {
-        content::g_force_cpu_draw = false;
-        LOG(WARNING) << "switch " << switches::kForceCpuDraw << " must be used with switch " << switches::kDisableGpu;
-      }
-    }
     manifest->GetBoolean(switches::kmTransparent, &transparent_);
   }
   LoadAppIconFromPackage(manifest);


### PR DESCRIPTION
use disable-gpu-compositing instead of disable-gpu
this pull request dependent on https://github.com/nwjs/chromium.src/pull/89
please also patch nw24