### PR TITLE
tools: remove the deprecated '--patch-config' option from patcher.py

### DIFF
--- a/tools/patcher.py
+++ b/tools/patcher.py
@@ -109,10 +109,6 @@ parser.add_option(
     dest='patchdir',
     metavar='DIR',
     help='patch target directory')
-# NWJS: Path of config file has been hard-coded in this script, so this option
-# is for compatibility purpose only, and it will be removed once it's no longer
-# used by the hook in //src/DEPS.
-parser.add_option('--patch-config', help='DEPRECATED: this is a no-op')
 (options, args) = parser.parse_args()
 
 if not options.patchfile is None:


### PR DESCRIPTION
This is the final step to finish the patcher.py upgrade, which depends on nwjs/nw.js#6121 and nwjs/chromium.src#92. Since we have removed its usage from //src/DEPS, the workaround can be reverted now to minimize the diff with the original tool.
