### PR TITLE
Incorrect guidelines for selenium test automation

### DIFF
--- a/docs/For Users/Advanced/Test with ChromeDriver.md
+++ b/docs/For Users/Advanced/Test with ChromeDriver.md
@@ -15,8 +15,7 @@ The following workflow uses [selenium-python](http://selenium-python.readthedocs
 
 ### Installing
 
-* Download ChromeDriver from NW.js website. It's in the SDK build.
-* Extract the package and place `chromedriver` under the same dir that contains the NW.js binaries: `nw` for Linux, `nw.exe` for Windows, or `node-webkit.app` for Mac.
+* Build your application with the SDK version of nw.js from the [official] (https://nwjs.io/) website
 * Install `selenium-python` in your project:
 ```bash
 pip install selenium


### PR DESCRIPTION
I tried exactly what was given in the current version of documentation for test automation using selenium on the nw.js application. According to the documentation, copying only the chrome driver from the SDK build to the application directory should work. But it didn't work for me and was throwing an error saying chrome not reachable. Fortunately, it worked when I built the application with the SDK version of nw.js. So I made a correction in the documentation on the same.