### PR TITLE
Update binary packaging to support ARM builds

### DIFF
--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -30,7 +30,7 @@ args = parser.parse_args()
 # Init variables.
 binaries_location = None        # .../out/Release
 platform_name = None            # win/linux/osx
-arch = None                     # ia32/x64
+arch = None                     # ia32/x64/arm
 step = None                     # nw/chromedriver/symbol
 skip = None
 nw_ver = None                   # x.xx
@@ -153,7 +153,6 @@ def generate_target_nw(platform_name, arch, version):
                            'nw',
                            'icudtl.dat',
                            'locales',
-                           'natives_blob.bin',
                            'v8_context_snapshot.bin',
                            'lib/libnw.so',
                            'lib/libnode.so',
@@ -172,12 +171,13 @@ def generate_target_nw(platform_name, arch, version):
             target['input'] += ['nacl_helper', 'nacl_helper_bootstrap', 'pnacl']
             if arch == 'x64':
                 target['input'].append('nacl_irt_x86_64.nexe')
-            else:
+            elif arch == 'ia32':
                 target['input'].append('nacl_irt_x86_32.nexe')
+            else:
+                target['input'].append('nacl_irt_{}.nexe'.format(arch))
             
     elif platform_name == 'win':
         target['input'] = [
-                           'natives_blob.bin',
                            'v8_context_snapshot.bin',
                            'd3dcompiler_47.dll',
                            'libEGL.dll',
@@ -219,7 +219,6 @@ def generate_target_nw(platform_name, arch, version):
             target['input'].append('chromedriver')
             target['input'].append('libffmpeg.dylib')
             target['input'].append('minidump_stackwalk')
-            target['input'].append('natives_blob.bin')
             target['input'].append('v8_context_snapshot.bin')
     else:
         print 'Unsupported platform: ' + platform_name


### PR DESCRIPTION
Fixes #7378 by removing `natives_blob.bin` from packaging requirements.
Also adds support for ARM builds where the NaCl IRT is named differently.