### PR TITLE
Fix Menu.append act different from SimpleMenuModel cause crash

### DIFF
--- a/src/resources/api_nw_menu.js
+++ b/src/resources/api_nw_menu.js
@@ -34,7 +34,15 @@ Menu.prototype.__defineSetter__('items', function(val) {
 });
 
 Menu.prototype.append = function(menu_item) {
-  privates(this).items.push(menu_item);
+  const isSeparator = menu_item.type === 'separator'
+  const items = privates(this).items
+  
+  // https://github.com/nwjs/chromium.src/blob/nw45-log/ui/base/models/simple_menu_model.h#L117
+  if (isSeparator && (items.length === 0 || items[items.length - 1].type === 'separator')) {
+    return menu_item._destroy()
+  }
+
+  items.push(menu_item);
   if (!menu_item.native)
     nw.Obj.callObjectMethod(this.id, 'Menu', 'Append', [ menu_item.id ]);
 };


### PR DESCRIPTION
NWJS Version :  nwjs-v0.45.0-beta1-linux-x64.tar.gz
Operating System : Ubuntu 19.10

#### Expected behavior

Popup menu become empty

#### Actual behavior

Program crashed

#### How to reproduce

Use the script below, then right click the body, select `Trigger Remove All MenuItem`

```html
<script>
var menu = new nw.Menu();

menu.append(new nw.MenuItem({ type: 'separator' }));
menu.append(new nw.MenuItem({
  label: 'Trigger Remove All MenuItem',
  click: function(){
    var i = menu.items.length - 1
    while (i >= 0) {
      menu.removeAt(i)
      i--
    }
  }
}));
menu.append(new nw.MenuItem({ label: 'Item B' }));
menu.append(new nw.MenuItem({ type: 'separator' }));
menu.append(new nw.MenuItem({ type: 'separator' }))
menu.append(new nw.MenuItem({ label: 'Item C' }));

document.body.addEventListener('contextmenu', function(ev) {
  ev.preventDefault();
  menu.popup(ev.x, ev.y);
  return false;
}, false);
</script>
```
The output

```
[8784:8784:0327/063840.807725:ERROR:component_loader.cc(169)] Failed to parse extension manifest.
[8784:8784:0327/063840.836020:ERROR:browser_switcher_service.cc(238)] XXX Init()
[8784:8784:0327/063842.557524:FATAL:simple_menu_model.cc(539)] Check failed: static_cast<size_t>(index) < items_.size() (5 vs. 4)
#0 0x7f3ae7c65629 (/nwjs/lib/libnw.so+0x4694628)
Task trace:
#0 0x7f3ae85d07f6 (/nwjs/lib/libnw.so+0x4fff7f5)
#1 0x7f3ae7daf9d6 (/nwjs/lib/libnw.so+0x47de9d5)
IPC message handler context: 0x73E4B09C

[1]    8784 abort (core dumped)  ./nwjs/nw .
```