### PR TITLE
Packaging docs: Correct typo with Linux app file zip name

### DIFF
--- a/docs/For Users/Package and Distribute.md
+++ b/docs/For Users/Package and Distribute.md
@@ -67,7 +67,7 @@ copy /b nw.exe+package.nw app.exe
 ```
 or following command on Linux:
 ```bash
-cat nw app.nw > app && chmod +x app 
+cat nw package.nw > app && chmod +x app 
 ```
 
 ## Platform Specific Steps


### PR DESCRIPTION
The title says it all. A few minor typo I noticed in the docs.