### PR TITLE
Expand Windows psudovars (ex; %APPDATA%) passed in chromium-args in t…

### DIFF
--- a/src/nw_package.cc
+++ b/src/nw_package.cc
@@ -46,6 +46,10 @@
 #include "third_party/node-nw/deps/uv/include/uv.h"
 #include "ui/base/resource/resource_bundle.h"
 
+#if defined(OS_WIN)
+#include <windows.h>
+#endif
+
 using base::CommandLine;
 
 namespace base {
@@ -463,6 +467,19 @@ void Package::ReadChromiumArgs() {
     if (!got_env)
       return;
 
+  // Expand Windows psudovars (ex; %APPDATA%) passed in chromium-args in the same way as when 
+  // passed as command line parameters.
+  #if defined(OS_WIN)
+  TCHAR szEnvPath[MAX_PATH];
+  std::wstring ws; 
+  ws.assign( args.begin(), args.end());
+  if (ExpandEnvironmentStrings(ws.c_str(), szEnvPath,MAX_PATH) != 0) {
+    std::wstring ws_out = szEnvPath;
+    args = std::string(ws_out.begin(), ws_out.end());
+  } else {
+    ReportError("Failed to expand chromium args",args.c_str());
+  }
+  #endif
   args = env_args + kChromiumArgsSeparator + args;
 
   std::vector<std::string> chromium_args;


### PR DESCRIPTION
…he same

way as when passed as command line parameters. This is the only way to set
the user-data-dir to the users roaming folder without creating a separate
launcher which isnt 100% fool proof since users can still run nw.exe directly.