### PR TITLE
Add js variable to check if AAC is successful or not

### DIFF
--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -894,6 +894,8 @@ NwCurrentWindowInternalToggleKioskModeInternalFunction::Run() {
 bool NwCurrentWindowInternalIsAACActiveInternalFunction::RunNWSync(base::ListValue* response, std::string* error) {
 #if defined(OS_MAC)
   response->AppendBoolean((NWGetAACActive()));
+#else
+  response->AppendBoolean(false);
 #endif
   return true;
 }

--- a/src/api/nw_window_api.cc
+++ b/src/api/nw_window_api.cc
@@ -891,6 +891,13 @@ NwCurrentWindowInternalToggleKioskModeInternalFunction::Run() {
   return RespondNow(NoArguments());
 }
 
+bool NwCurrentWindowInternalIsAACActiveInternalFunction::RunNWSync(base::ListValue* response, std::string* error) {
+#if defined(OS_MAC)
+  response->AppendBoolean((NWGetAACActive()));
+#endif
+  return true;
+}
+
 bool NwCurrentWindowInternalIsKioskInternalFunction::RunNWSync(base::ListValue* response, std::string* error) {
   if (base::FeatureList::IsEnabled(::features::kNWNewWin)) {
     int id = 0;

--- a/src/api/nw_window_api.h
+++ b/src/api/nw_window_api.h
@@ -259,6 +259,16 @@ class NwCurrentWindowInternalToggleKioskModeInternalFunction : public ExtensionF
    DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.toggleKioskModeInternal", UNKNOWN)
 };
 
+class NwCurrentWindowInternalIsAACActiveInternalFunction : public NWSyncExtensionFunction {
+ public:
+  NwCurrentWindowInternalIsAACActiveInternalFunction() {}
+  bool RunNWSync(base::ListValue* response, std::string* error) override;
+
+ protected:
+  ~NwCurrentWindowInternalIsAACActiveInternalFunction() override {}
+  DECLARE_EXTENSION_FUNCTION("nw.currentWindowInternal.isAACActiveInternal", UNKNOWN)
+};
+
 class NwCurrentWindowInternalIsKioskInternalFunction : public NWSyncExtensionFunction {
  public:
   NwCurrentWindowInternalIsKioskInternalFunction() {}

--- a/src/nw_content_mac.h
+++ b/src/nw_content_mac.h
@@ -17,4 +17,5 @@ void NWSetNSWindowShowInTaskbar(extensions::NativeAppWindow* win, bool show);
 void NWSetNSWindowShowInTaskbar(gfx::NativeWindow win, bool show);
 void NWSetNSAppKioskOptions(void);
 void NWRestoreNSAppKioskOptions(void);
+bool NWGetAACActive(void);
 #endif

--- a/src/nw_content_mac.mm
+++ b/src/nw_content_mac.mm
@@ -175,3 +175,10 @@ void NWRestoreNSAppKioskOptions(void) {
         }
     }
 }
+
+bool NWGetAACActive(void) {
+    if (@available(macOS 10.15.4, *)) {
+        return [session isActive];
+    }
+    return false;
+}

--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -588,6 +588,11 @@ apiBridge.registerCustomHook(function(bindingsAPI) {
         return this.appWindow.alphaEnabled();
       }
     });
+    Object.defineProperty(NWWindow.prototype, 'isAACActive', {
+      get: function() {
+        return currentNWWindowInternal.isAACActiveInternal();
+      }
+    });
     Object.defineProperty(NWWindow.prototype, 'isKioskMode', {
       get: function() {
         return currentNWWindowInternal.isKioskInternal();


### PR DESCRIPTION
Original AAC PR: https://github.com/nwjs/nw.js/pull/7698

While testing AAC feature, I realized that it would be nice to have a variable whose value reflects the successful start of AAC instead of having to look into the logs. The purpose of this PR is to add such a variable. 

More details about this pull request:
1. It adds a javascript variable called "isAACActive" which checks the value of session.active. The value of session.active is set by the successful start of AAC. 
Example: 
let x = nw.Window.get(window); x.enterKioskMode(); 
...
console.log(x.isAACActive); // It should return True if AAC starts and False otherwise.
2. The value of the variable "x.isAACActive" is set to False by default on non-OSX platforms. 

Note: I have a hard time building it to fully test it but I hope that the code is okay and may be it can be tested from the build system's nightly build. 