### PR TITLE
Add a note about ESM to the first Google result for NW.js ESM

### DIFF
--- a/docs/For Users/Advanced/Use Native Node Modules.md
+++ b/docs/For Users/Advanced/Use Native Node Modules.md
@@ -3,6 +3,21 @@
 
 [TOC]
 
+## ESM
+
+NW.js does not currently support referencing Node modules using the ESM syntax
+(`import`/`export`). Please use CJS `require`:
+
+```js
+// Supported
+const fs = require('fs');
+
+// Not supported
+import fs from 'fs';
+```
+
+[Tracking issue](https://github.com/nwjs/nw.js/issues/7639)
+
 ## Install with NPM
 
 ### For LTS Releases


### PR DESCRIPTION
Hi, I am a new NW.js user and I was looking up information related to ESM support in NW.js related to Node modules. I tested on the latest SDK and it looks like ESM syntax is supported for browser context JS, but the Node side needs to be handled using CJS `require`. I also found #7639 which talks about this.

I hope ESM support can be added soon, it would be awesome to have something like this:

```js
import something from './something.js';
import fs from 'fs';

await fs.promises.writeFile('file.ext', something());
```

While this is not possible using ESM, I am proposing an update to the NW.js documentation highlighting it. The page I have edited is the first Google hit for "NW.js ESM". I hope this addition is accepted to reduce confusion of future new users. Thanks for considering including it.