### PR TITLE
Added Typescript integration docs.md

### DIFF
--- a/docs/For Developers/Typescript Integration.md
+++ b/docs/For Developers/Typescript Integration.md
@@ -1,0 +1,21 @@
+# Typescript Integration {:.doctitle}
+---
+## A. Using community definitions for global `nw` object
+
+NW.js does not provide offical typescript definitions however you can integrate the community definitions by
+1. Installing the [community type definitions package](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/nw.gui): `@types/nw.gui`.
+2. Creating a file called *nw.d.ts* with the following content:
+```ts
+declare var nw: typeof import('nw.gui')
+```
+After this typescript should not complain anymore about the "`undefined`" global `nw` object, 
+also be aware that the community definitions may not always match the latest NW.js API, 
+however if you face a problems with the current type definitions you can opt the solution B.
+
+## B. Disabling type checking for global `nw` object
+
+Create a file called *nw.d.ts* with the following content 
+
+```ts
+declare var nw: any
+```


### PR DESCRIPTION
added basic docs for typescript integration using community definitions, there is no documentation about this, so i think it's good to mention it on the official docs, it was a headache to me to figure out this simple setup, glad to share. 

This docs content may be subject to change as the nw.js team believes more convenient.