### PR TITLE
fix(docs): Remove unmaintained way to package nw.js from docs

### DIFF
--- a/docs/For Users/Package and Distribute.md
+++ b/docs/For Users/Package and Distribute.md
@@ -9,7 +9,6 @@ This document guides you how to package and distribute NW.js based app.
 
 You can use following tools to automatically package your NW.js based app for distribution.
 
-* [nwjs-builder-phoenix](https://github.com/evshiron/nwjs-builder-phoenix) (recommended)
 * [nw-builder](https://github.com/nwjs-community/nw-builder)
 
 Or your can build your app manually with the instructions below.


### PR DESCRIPTION
As stated in https://github.com/nwjs/nw.js/issues/7693, nwjs-builder-phoenix has not be maintained for years.

Every now and then, there are more CVE opened on dependencies, that cannot be updated with this package, this shouldn't be a recommended package builder anymore.

This PR removes link to this builder in the documentation.