### PR TITLE
fix(plist): bump `CFBundleShortVersionString` to 0.67.1

### DIFF
--- a/src/mac/app-Info.plist
+++ b/src/mac/app-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.1</string>
+	<string>0.67.1</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Judging by [this commit](https://github.com/nwjs/nw.js/commit/f19f7139e0d182fb3724089431faeb918a5aa527#), should `CFBundleShortVersionString` be set to 0.67.1?