### PR TITLE
chore(docs): add link to `nw-bug-repro` in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,8 @@ Before opening an issue, please search and see if it has already been raised.
 
 > Please use our [mailing list](https://groups.google.com/forum/#!forum/nwjs-general) or [Gitter chatroom](https://gitter.im/nwjs/nw.js) to ask questions. The issue tracker is only for bugs and feature requests, in English only. Please note that issues without a repro or code snippet are less likely to be resolved.
 
+We'd recommend creating your reproduction by opening a pull request against [nw-bug-repro](https://github.com/nwutils/nw-bug-repro) and linking it here in `Repro Link` below.
+
 ### Current/Missing Behavior
 
 ### Expected/Proposed Behavior


### PR DESCRIPTION
# Description

It gets pretty tedious and draining to create repros for bug reports. Through the [`nw-bug-repro`](https://github.com/nwutils/nw-bug-repro) repository, users can branch off the repo, create their reproduction, open a pull request and link it in their bug reports. This will make it easier for everyone to pinpoint issues and work on them.