### PR TITLE
Fixes nwjs#8039; Grey default icon in taskbar on Windows

### DIFF
--- a/src/browser/nw_extensions_browser_hooks.cc
+++ b/src/browser/nw_extensions_browser_hooks.cc
@@ -286,7 +286,7 @@ void LoadNWAppAsExtensionHook(base::Value::Dict* manifest,
       SetAppIcon(app_icon);
       int width = app_icon.Width();
       std::string key = "icons." + base::NumberToString(width);
-      manifest->Set(key, *icon_path);
+      manifest->SetByDottedPath(key, *icon_path);
 #if defined(OS_WIN)
       SetWindowHIcon((IconUtil::CreateHICONFromSkBitmapSizedTo(*app_icon.AsImageSkia().bitmap(),
                       GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON))));


### PR DESCRIPTION
Previous fix was not sufficient.  We also need to use the updated Chromium `base::Value` api call, `SetByDottedPath()` when manipulating the manifest values via a dotted path name.