### PR TITLE
Throw error if `showDevTools` is called from non-`sdk` build flavor

### DIFF
--- a/docs/References/Window.md
+++ b/docs/References/Window.md
@@ -298,6 +298,7 @@ Turn the window's native shadow on/off. Useful for frameless, transparent window
 
 * `iframe` `{String} or {HTMLIFrameElement}` _Optional_ the id or the element of the `<iframe>` to be jailed on. By default, the DevTools is shown for entire window.
 * `callback(dev_win)` `{Function}` callback with the native window of the DevTools window.
+* Throws error if build flavor is not `sdk`.
 
 Open the devtools to inspect the window.
 

--- a/src/resources/api_nw_newwin.js
+++ b/src/resources/api_nw_newwin.js
@@ -370,6 +370,8 @@ NWWindow.prototype.toggleKioskMode = function() {
 };
 
 NWWindow.prototype.showDevTools = function(frm, callback) {
+  if (process.versions['nw-flavor'] !== 'sdk')
+    throw new Error('showDevTools does not exist on' + process.versions['nw-flavor'] + 'build flavor.');
   var id = '';
   if (typeof frm === 'string')
     id = frm;

--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -372,6 +372,8 @@ apiBridge.registerCustomHook(function(bindingsAPI) {
     };
 
     NWWindow.prototype.showDevTools = function(frm, callback) {
+      if (process.versions['nw-flavor'] !== 'sdk')
+        throw new Error('showDevTools does not exist on' + process.versions['nw-flavor'] + 'build flavor.');
       var id = '';
       if (typeof frm === 'string')
         id = frm;


### PR DESCRIPTION
Fixes: #8012
Fixes: #7844

If `showDevTools` is called from non-`sdk` build, then application crashes and has to be manually terminated. This prevents the crash and throws an error instead.