### PR TITLE
[resources] Coerce `RegExp.exec`'s `Array | null` return type to truthy or falsy

### DIFF
--- a/docs/References/Window.md
+++ b/docs/References/Window.md
@@ -387,7 +387,7 @@ For platforms that support multiple workspaces (currently Mac OS X and Linux), t
 
 ## win.canSetVisibleOnAllWorkspaces() (Mac and Linux)
 
-Returns a a boolean indicating if the platform (currently Mac OS X and Linux) support Window API method `setVisibleOnAllWorkspace(Boolean)`.
+Returns a `boolean` indicating if the platform (currently Mac OS X and Linux) supports `win.setVisibleOnAllWorkspace(Boolean)`.
 
 ## win.setPosition(position)
 

--- a/src/resources/api_nw_newwin.js
+++ b/src/resources/api_nw_newwin.js
@@ -41,7 +41,7 @@ function getPlatform() {
   return "unknown";
 }
 
-var canSetVisibleOnAllWorkspaces = /(mac|linux)/.exec(getPlatform());
+var canSetVisibleOnAllWorkspaces = !!(/(mac|linux)/.exec(getPlatform()));
 
 var nwWinEventsMap = {
   'minimize':         'onMinimized',

--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -107,7 +107,7 @@ function getPlatform() {
   return "unknown";
 }
 
-var canSetVisibleOnAllWorkspaces = /(mac|linux)/.exec(getPlatform());
+var canSetVisibleOnAllWorkspaces = !!(/(mac|linux)/.exec(getPlatform()));
 var appWinEventsMap = {
   'minimize':         'onMinimized',
   'maximize':         'onMaximized',


### PR DESCRIPTION
### Description of Changes

[canSetVisibleOnAllWorkspaces](https://github.com/nwjs/nw.js/blob/964f649e7d39b9ff3a5532eece93ca0ad51b665e/src/resources/api_nw_newwin.js#L45) returns an `Array | null` instead of boolean type due to [RegExp.exec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec). When platform is Linux or Mac, it returns an array, otherwise it returns `null`. The fix is to coerce RegExp.exec's `Array | null` return type to truthy or falsy. The array gets coerced to `true` and null to `false`. I have also added a test to prevent this behaviour from regressing in the future.

Fixes: #8146