### PR TITLE
Remove theora support from document

### DIFF
--- a/docs/For Developers/Enable Proprietary Codecs.md
+++ b/docs/For Developers/Enable Proprietary Codecs.md
@@ -7,7 +7,6 @@
 
 As NW.js is based on Chromium, the media components are essentially the same. In the pre-built NW.js, the following codecs are supported:
 
-    - theora
     - vorbis
     - vp8 & vp9
     - pcm_u8, pcm_s16le, pcm_s24le, pcm_f32le, pcm_s16be & pcm_s24be


### PR DESCRIPTION
`theora` is no longer supported by Chromium (at least via ffmpeg).

See kAllowedAudioCodecs of https://github.com/chromium/chromium/blob/main/media/ffmpeg/ffmpeg_common.cc