### PR TITLE
Add dump task dependency to dist task

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -411,6 +411,7 @@ executable("payload") {
 
 if (!is_component_build) {
   action("dist") {
+    testonly = true
     script = "tools/package_binaries.py"
     if (nwjs_sdk) {
       package_mode = "sdk"
@@ -429,7 +430,10 @@ if (!is_component_build) {
       "-m", "$package_mode",
       "-i", "$icudat_path"
     ]
-    deps = [ "//components/resources:about_credits_nw" ]
+    deps = [
+      "//components/resources:about_credits_nw",
+      ":dump"
+    ]
     if (nwjs_sdk && (is_mac || is_linux)) {
       deps += [ "//third_party/breakpad:minidump_stackwalk" ]
     }


### PR DESCRIPTION
## Description

This PR addresses the build failure in the dist task caused by a missing dependency on the dump task. The `package_binaries.py` script in the dist action relies on nw.sym.7z (generated exclusively by the dump task), but the dependency was not explicitly declared in `BUILD.gn`. This led to Ninja executing the dist task while entirely skipping the dump task in fresh builds, resulting in a "missing nw.sym.7z" error.

## Related Issue(s)

fix #8330 
