### PR TITLE
[docs] Add package instruction

### DIFF
--- a/docs/For Developers/Building NW.js.md
+++ b/docs/For Developers/Building NW.js.md
@@ -145,6 +145,17 @@ cd src
 ninja -C out/nw copy_node
 ```
 
+To package the NW.js binary into a distributable zip archive:
+
+```bash
+cd src
+ninja -C out/nw dump # Required by `dist` target
+ninja -C out/nw dist
+```
+
+!!! tip "Build with GitHub Actions"
+    [kazutoiris/NW.js-Build](https://github.com/kazutoiris/NW.js-Build) offers a seamless approach to building NW.js on Windows via GitHub Actions.
+
 ## Build Flavors
 
 * Standard: 'nwjs_sdk=false'


### PR DESCRIPTION
This PR adds clear instructions for packaging built NW.js binaries into a distributable zip archive via Ninja targets. This fills a gap in the existing documentation by offering a standardized method for creating shareable and distributable builds.

Additionally, it includes a tip featuring a seamless GitHub Actions workflow for building NW.js on Windows, which assists Windows developers in bypassing the complexities of manual environment configuration.