### PR TITLE
[CI] Run automated test suite on Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,64 @@
+name: Windows automated tests
+
+# Runs the NW.js automated ("auto") test suite on Windows against a prebuilt
+# NW.js SDK. Building NW.js/Chromium from source is far too large for a hosted
+# runner, so — as the nightly-test docs describe — we download the matching SDK
+# build and point the test runner at it with `test/test.py -d <nwdir>`.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # NW.js release to test against. Keep in sync with the version in README.md.
+  NWJS_VERSION: "0.112.0"
+
+jobs:
+  auto-suite:
+    name: auto suite (win-x64)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # test/test.py uses `import imp` (gone in 3.12) and a positional
+      # json.loads(..., 'utf-8') encoding arg (gone in 3.9), so it only runs on
+      # Python <= 3.8.
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Cache NW.js SDK
+        id: cache-nwjs
+        uses: actions/cache@v4
+        with:
+          path: nwjs-sdk.zip
+          key: nwjs-sdk-${{ env.NWJS_VERSION }}-win-x64
+
+      - name: Download NW.js SDK ${{ env.NWJS_VERSION }}
+        if: steps.cache-nwjs.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $url = "https://dl.nwjs.io/v$env:NWJS_VERSION/nwjs-sdk-v$env:NWJS_VERSION-win-x64.zip"
+          Write-Host "Downloading $url"
+          $ProgressPreference = 'SilentlyContinue'   # huge speed-up for large files
+          Invoke-WebRequest -Uri $url -OutFile nwjs-sdk.zip
+
+      - name: Extract NW.js SDK
+        shell: pwsh
+        run: Expand-Archive -Path nwjs-sdk.zip -DestinationPath . -Force
+
+      - name: Run auto test suite
+        shell: pwsh
+        run: |
+          $nwdir = Join-Path (Get-Location) "nwjs-sdk-v$env:NWJS_VERSION-win-x64"
+          if (-not (Test-Path (Join-Path $nwdir "nw.exe"))) {
+            throw "nw.exe not found in $nwdir"
+          }
+          Write-Host "Running auto suite against $nwdir"
+          python test/test.py -d $nwdir -t 80 --no-build -p dots auto


### PR DESCRIPTION
## What

Adds the first GitHub Actions workflow (`.github/workflows/test-windows.yml`) that runs the NW.js automated (`auto`) test suite on a `windows-latest` runner.

## How

- Downloads (and caches) the matching prebuilt **NW.js SDK** for `win-x64` and points `test/test.py` at it via `-d`. Building NW.js/Chromium from source is impractical on a hosted runner, so this follows the documented nightly-test approach (`docs/For Developers/Writing Test Cases for NW.js.md`).
- Runs `python test/test.py -d <nwdir> -t 80 --no-build -p dots auto`.
- Triggers on push to `main`, pull requests, and manual `workflow_dispatch`.
- `NWJS_VERSION` is a single env var (currently `0.112.0`) to keep in sync with `README.md`.

## Notes

Python is pinned to **3.8** because `test/test.py` relies on `imp` (removed in 3.12) and a positional `json.loads(..., 'utf-8')` encoding arg (removed in 3.9). A follow-up could modernize `test.py` to run on a current Python; this PR intentionally keeps the change to just adding the CI step.

Scope is the `auto` suite only — the `remoting`/`sanity` suites additionally need ChromeDriver + Selenium, which can be layered on later using the same structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)