### PR TITLE
docs: document webview sizing styles

### DIFF
--- a/docs/For Developers/Contributors of Documents.md
+++ b/docs/For Developers/Contributors of Documents.md
@@ -5,3 +5,4 @@
 * Cong Liu <cong.liu@intel.com>
 * Oleg Aleynik <oleg.aleynik@gmail.com>
 * Yang Fan <yangfan.23@qq.com>
+* Rajesh Digambar Bagul <102693488+Rajesh270712@users.noreply.github.com>

--- a/docs/References/webview Tag.md
+++ b/docs/References/webview Tag.md
@@ -13,6 +13,29 @@ To embed a web page in your app, add the webview tag to your app's embedder page
 <webview id="foo" src="http://www.google.com/" style="width:640px; height:480px"></webview>
 ```
 
+For predictable sizing, give `<webview>` an explicit layout display and size. If a `<webview>` is expected to fill its window or parent container, make sure the parent has a defined size and style the `<webview>` with a flex-compatible display. Treat this as a CSS layout requirement for the embedder page, not as a runtime resize fix.
+
+For example, a full-window `<webview>` can be styled like this:
+
+```html
+<style>
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+webview {
+  display: inline-flex;
+  width: 100%;
+  height: 100%;
+}
+</style>
+
+<webview src="http://www.google.com/"></webview>
+```
+
 ## References
 
 See [Chrome document of `<webview>` tag](https://developer.chrome.com/docs/extensions/reference/webviewTag/) for detailed API references.


### PR DESCRIPTION
## Summary
- Document the CSS sizing requirements for `<webview>` so full-window/parent-filling use cases have a concrete example.
- Add the document contributor entry required by the docs contribution checklist.

## Linked issue / bounty
- Fixes https://github.com/nwjs/nw.js/issues/4189
- IssueHunt: https://oss.issuehunt.io/r/nwjs/nw.js/issues/4189

## Problem
The issue thread shows that `<webview>` sizing can look broken unless the embedder page gives the element and its parent explicit sizing and a flex-compatible display. The workaround is discussed in the issue, but the reference page did not mention it.

## Fix
This PR adds a docs-only note to `docs/References/webview Tag.md` explaining the layout requirement and includes a minimal full-window example using `display: inline-flex`, `width: 100%`, and `height: 100%`.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 -m venv .venv && .venv/bin/python -m pip install -r requirements.txt && .venv/bin/mkdocs build`
- Generated HTML/source content check for `predictable sizing`, `full-window`, `inline-flex`, `width: 100%`, and `height: 100%`
- GitHub issue rechecked open; no open same-surface PRs found

## Risk / limitations
- Docs-only change; no NW.js runtime behavior is changed or claimed.
- The example is intentionally minimal and may need wording/placement tweaks if maintainers prefer a different style.
