### PR TITLE
Add ARM (armhf/armel) prebuilt binary support

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -1,0 +1,286 @@
+name: Build ARM (armhf/armel)
+
+on:
+  push:
+    branches: [master, nwjs]
+    paths:
+      - 'BUILD.gn'
+      - '.github/workflows/build-arm.yml'
+  pull_request:
+    branches: [master, nwjs]
+  workflow_dispatch:
+    inputs:
+      target_arch:
+        description: 'Target architecture (arm or arm64)'
+        required: false
+        default: 'arm'
+        type: choice
+        options:
+          - arm
+          - arm64
+
+env:
+  CHROMIUM_BUILDTOOLS_PATH: src/buildtools
+
+jobs:
+  build-arm-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target_arch: [arm]
+        build_type: [Release]
+        nwjs_sdk: [true, false]
+      fail-fast: false
+
+    name: NW.js ${{ matrix.nwjs_sdk && 'SDK' || 'Normal' }} Linux ${{ matrix.target_arch }} (${{ matrix.build_type }})
+
+    steps:
+      - name: Checkout nw.js
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_arch && format('refs/heads/{0}', github.ref) || github.ref }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3 \
+            git \
+            curl \
+            wget \
+            build-essential \
+            pkg-config \
+            gperf \
+            bison \
+            flex \
+            libnotify-dev \
+            libgconf2-dev \
+            libgnome-keyring-dev \
+            libgirepository1.0-dev \
+            libdbus-1-dev \
+            libgtk-3-dev \
+            libboost-dev \
+            libdrm-dev \
+            libxkbcommon-dev \
+            libatspi2.0-dev \
+            libxss-dev \
+            libasound2-dev \
+            libcups2-dev \
+            libpulse-dev \
+            libudev-dev \
+            libpci-dev \
+            libnss3-dev \
+            libxrandr-dev \
+            libglib2.0-dev \
+            libxcomposite-dev \
+            libxdamage-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libxml2-dev
+
+      - name: Install cross-compilation toolchain for ARM
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-arm-linux-gnueabihf \
+            g++-arm-linux-gnueabihf \
+            libc6-dev-armhf-cross
+
+      - name: Fetch depot_tools
+        run: |
+          if [ ! -d depot_tools ]; then
+            git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+          fi
+          export PATH="$PWD/depot_tools:$PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Fetch nw.js source
+        run: |
+          gclient config --name src/nw.js --unmanaged https://github.com/${{ github.repository }}.git
+          gclient sync --nohooks -D --force --reset -R
+          cd src/nw.js
+          git checkout ${{ github.sha }} || true
+          cd ../..
+
+      - name: GN gen for ARM cross-compile
+        run: |
+          cd src
+          gn gen out/Release --args='
+            is_debug = false
+            target_cpu = "arm"
+            is_component_build = false
+            is_official_build = true
+            nwjs_sdk = ${{ matrix.nwjs_sdk }}
+            use_sysroot = true
+            treat_warnings_as_errors = false
+            enable_nacl = false
+            is_desktop_linux = true
+            use_qt = false
+            use_ozone = true
+            ozone_platform = "x11"
+            use_vaapi = false
+            use_v4l2_codec = false
+            use_va = false
+            use_cups = false
+            use_dbus = false
+            use_gio = false
+            use_kerberos = false
+            use_libpci = false
+            use_pulseaudio = false
+            use_udev = false
+            symbol_level = 0
+            blink_symbol_level = 0
+            v8_symbol_level = 0
+            chrome_pgo_phase = 0
+          '
+
+      - name: Build nw.js for ARM
+        run: |
+          cd src
+          autoninja -C out/Release nwjs dist
+        timeout-minutes: 360
+
+      - name: Upload ARM artifacts
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: nwjs-linux-arm-${{ matrix.nwjs_sdk && 'sdk' || 'normal' }}-${{ matrix.build_type }}
+          path: |
+            src/out/Release/dist/*.tar.gz
+            src/out/Release/dist/*.sha256.txt
+          retention-days: 30
+
+      - name: Upload symbols
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: nwjs-linux-arm-symbols-${{ matrix.nwjs_sdk && 'sdk' || 'normal' }}
+          path: |
+            src/out/Release/*.sym
+          retention-days: 30
+
+  build-arm64-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Release]
+        nwjs_sdk: [true, false]
+      fail-fast: false
+
+    name: NW.js ${{ matrix.nwjs_sdk && 'SDK' || 'Normal' }} Linux arm64 (${{ matrix.build_type }})
+
+    steps:
+      - name: Checkout nw.js
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3 \
+            git \
+            curl \
+            wget \
+            build-essential \
+            pkg-config \
+            gperf \
+            bison \
+            flex \
+            libnotify-dev \
+            libgconf2-dev \
+            libgnome-keyring-dev \
+            libgirepository1.0-dev \
+            libdbus-1-dev \
+            libgtk-3-dev \
+            libboost-dev \
+            libdrm-dev \
+            libxkbcommon-dev \
+            libatspi2.0-dev \
+            libxss-dev \
+            libasound2-dev \
+            libcups2-dev \
+            libpulse-dev \
+            libudev-dev \
+            libpci-dev \
+            libnss3-dev \
+            libxrandr-dev \
+            libglib2.0-dev \
+            libxcomposite-dev \
+            libxdamage-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libxml2-dev
+
+      - name: Fetch depot_tools
+        run: |
+          if [ ! -d depot_tools ]; then
+            git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+          fi
+          export PATH="$PWD/depot_tools:$PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Fetch nw.js source
+        run: |
+          gclient config --name src/nw.js --unmanaged https://github.com/${{ github.repository }}.git
+          gclient sync --nohooks -D --force --reset -R
+          cd src/nw.js
+          git checkout ${{ github.sha }} || true
+          cd ../..
+
+      - name: GN gen for ARM64 cross-compile
+        run: |
+          cd src
+          gn gen out/Release --args='
+            is_debug = false
+            target_cpu = "arm64"
+            is_component_build = false
+            is_official_build = true
+            nwjs_sdk = ${{ matrix.nwjs_sdk }}
+            use_sysroot = true
+            treat_warnings_as_errors = false
+            enable_nacl = false
+            is_desktop_linux = true
+            use_qt = false
+            use_ozone = true
+            ozone_platform = "x11"
+            use_vaapi = false
+            use_v4l2_codec = false
+            use_va = false
+            use_cups = false
+            use_dbus = false
+            use_gio = false
+            use_kerberos = false
+            use_libpci = false
+            use_pulseaudio = false
+            use_udev = false
+            symbol_level = 0
+            blink_symbol_level = 0
+            v8_symbol_level = 0
+            chrome_pgo_phase = 0
+          '
+
+      - name: Build nw.js for ARM64
+        run: |
+          cd src
+          autoninja -C out/Release nwjs dist
+        timeout-minutes: 360
+
+      - name: Upload ARM64 artifacts
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: nwjs-linux-arm64-${{ matrix.nwjs_sdk && 'sdk' || 'normal' }}-${{ matrix.build_type }}
+          path: |
+            src/out/Release/dist/*.tar.gz
+            src/out/Release/dist/*.sha256.txt
+          retention-days: 30
+
+      - name: Upload symbols
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: nwjs-linux-arm64-symbols-${{ matrix.nwjs_sdk && 'sdk' || 'normal' }}
+          path: |
+            src/out/Release/*.sym
+          retention-days: 30

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -366,6 +366,9 @@ if (is_linux && !is_component_build) {
   if (target_cpu == "x86") {
     arch_pkgname = "ia32"
   }
+  if (target_cpu == "arm") {
+    arch_pkgname = "armhf"
+  }
   action_foreach("dump") {
     testonly = true
     script = "//build/linux/dump_app_syms.py"
@@ -463,6 +466,9 @@ if (!is_component_build) {
     arch_pkgname = target_cpu
     if (target_cpu == "x86") {
       arch_pkgname = "ia32"
+    }
+    if (target_cpu == "arm") {
+      arch_pkgname = "armhf"
     }
     icudat_path = rebase_path("../../third_party/icu/common/icudtl.dat")
     outputs = [ "$root_build_dir/new_package.re" ]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It was created in the Intel Open Source Technology Center.
 ## Downloads
 * **v0.115.0:** (August 18th, 2026, based off of Node.js v26.7.0, Chromium 152) : [release notes](https://nwjs.io/blog/v0.115.0/)
  **NOTE** You might want the **SDK build**. Please read the release notes.
- * Linux: [64bit](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-linux-x64.tar.gz) / [arm64](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-linux-arm64.tar.gz)
+ * Linux: [64bit](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-linux-x64.tar.gz) / [arm64](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-linux-arm64.tar.gz) / [armhf](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-linux-armhf.tar.gz)
  * Windows: [32bit](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-win-ia32.zip) / [64bit](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-win-x64.zip)
  * Mac 10.10+: [64bit](https://dl.nwjs.io/v0.115.0/nwjs-v0.115.0-osx-arm64.zip)
  * Use [Legacy build](http://nwjs.io/downloads/) for Win XP and early OSX.

--- a/docs/Building-ARM.md
+++ b/docs/Building-ARM.md
@@ -1,0 +1,223 @@
+# Building NW.js for ARM Devices
+
+This document describes how to cross-compile NW.js for ARM (armhf/armel) and ARM64 (aarch64) targets on a Linux host.
+
+## Prerequisites
+
+### Host System Requirements
+
+- Ubuntu 20.04+ or Debian 11+ (x86_64)
+- At least 16GB RAM (32GB+ recommended)
+- 100GB+ free disk space
+- Fast internet connection (for fetching Chromium dependencies)
+
+### Install Build Dependencies
+
+```bash
+# For 32-bit ARM (armhf) cross-compilation
+sudo dpkg --add-architecture armhf
+sudo apt-get update
+sudo apt-get install -y \
+  gcc-arm-linux-gnueabihf \
+  g++-arm-linux-gnueabihf \
+  libc6-dev-armhf-cross
+
+# For 64-bit ARM (arm64/aarch64) cross-compilation
+sudo dpkg --add-architecture arm64
+sudo apt-get update
+sudo apt-get install -y \
+  gcc-aarch64-linux-gnu \
+  g++-aarch64-linux-gnu \
+  libc6-dev-arm64-cross
+
+# Common build dependencies
+sudo apt-get install -y \
+  python3 git curl wget build-essential pkg-config \
+  gperf bison flex libnotify-dev libgconf2-dev \
+  libgnome-keyring-dev libgirepository1.0-dev \
+  libdbus-1-dev libgtk-3-dev libboost-dev \
+  libdrm-dev libxkbcommon-dev libatspi2.0-dev \
+  libxss-dev libasound2-dev libcups2-dev \
+  libpulse-dev libudev-dev libpci-dev libnss3-dev \
+  libxrandr-dev libglib2.0-dev libxcomposite-dev \
+  libxdamage-dev libxext-dev libxfixes-dev libxml2-dev
+```
+
+### Fetch depot_tools
+
+```bash
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH="$PWD/depot_tools:$PATH"
+```
+
+## Fetching Source Code
+
+```bash
+# Create working directory
+mkdir -p ~/nwjs-arm && cd ~/nwjs-arm
+
+# Configure gclient
+gclient config --name src/nw.js https://github.com/nwjs/nw.js.git
+
+# Sync dependencies (this will take a while)
+gclient sync --nohooks
+```
+
+## Building for ARM (armhf)
+
+ARM hard-float (armhf) is the most common 32-bit ARM target, used on Raspberry Pi and similar devices.
+
+### Generate Build Files
+
+```bash
+cd src
+
+gn gen out/Release-arm --args='
+  is_debug = false
+  target_cpu = "arm"
+  is_component_build = false
+  is_official_build = true
+  nwjs_sdk = false
+  use_sysroot = true
+  treat_warnings_as_errors = false
+  enable_nacl = false
+  is_desktop_linux = true
+  use_qt = false
+  use_ozone = true
+  ozone_platform = "x11"
+  use_vaapi = false
+  use_v4l2_codec = false
+  use_va = false
+  use_cups = false
+  use_dbus = false
+  use_gio = false
+  use_kerberos = false
+  use_libpci = false
+  use_pulseaudio = false
+  use_udev = false
+  symbol_level = 0
+  blink_symbol_level = 0
+  v8_symbol_level = 0
+  chrome_pgo_phase = 0
+'
+```
+
+### Build
+
+```bash
+autoninja -C out/Release-arm nwjs dist
+```
+
+### Output
+
+The built binaries will be in `src/out/Release-arm/dist/` as a `.tar.gz` archive:
+- `nwjs-vX.Y.Z-linux-armhf.tar.gz` (normal build)
+- `nwjs-sdk-vX.Y.Z-linux-armhf.tar.gz` (SDK build with devtools)
+
+## Building for ARM64 (aarch64)
+
+ARM64 is the 64-bit ARM architecture, used on modern ARM devices like Raspberry Pi 4/5 (64-bit OS), Apple Silicon (via Linux VMs), and ARM servers.
+
+### Generate Build Files
+
+```bash
+cd src
+
+gn gen out/Release-arm64 --args='
+  is_debug = false
+  target_cpu = "arm64"
+  is_component_build = false
+  is_official_build = true
+  nwjs_sdk = false
+  use_sysroot = true
+  treat_warnings_as_errors = false
+  enable_nacl = false
+  is_desktop_linux = true
+  use_qt = false
+  use_ozone = true
+  ozone_platform = "x11"
+  use_vaapi = false
+  use_v4l2_codec = false
+  use_va = false
+  use_cups = false
+  use_dbus = false
+  use_gio = false
+  use_kerberos = false
+  use_libpci = false
+  use_pulseaudio = false
+  use_udev = false
+  symbol_level = 0
+  blink_symbol_level = 0
+  v8_symbol_level = 0
+  chrome_pgo_phase = 0
+'
+```
+
+### Build
+
+```bash
+autoninja -C out/Release-arm64 nwjs dist
+```
+
+### Output
+
+The built binaries will be in `src/out/Release-arm64/dist/` as a `.tar.gz` archive:
+- `nwjs-vX.Y.Z-linux-arm64.tar.gz` (normal build)
+- `nwjs-sdk-vX.Y.Z-linux-arm64.tar.gz` (SDK build with devtools)
+
+## SDK vs Normal Build
+
+- **Normal build**: Minimal runtime, no devtools or chromedriver
+- **SDK build**: Includes Chrome DevTools and chromedriver for development/debugging
+
+Set `nwjs_sdk = true` for SDK builds, `nwjs_sdk = false` for normal builds.
+
+## Testing on ARM Devices
+
+### Using QEMU (on x86_64 host)
+
+```bash
+# Install QEMU user-mode emulation
+sudo apt-get install qemu-user-static binfmt-support
+
+# Register binfmt handlers
+sudo update-binfmts --enable qemu-arm
+sudo update-binfmts --enable qemu-aarch64
+
+# Test the binary (will run via QEMU)
+./nw /path/to/your/app
+```
+
+### On Real Hardware
+
+Copy the `.tar.gz` to your ARM device and extract:
+
+```bash
+tar xzf nwjs-v*.tar.gz
+cd nwjs-v*/
+./nw /path/to/your/app
+```
+
+## Troubleshooting
+
+### "failed to locate toolchain" error
+Ensure depot_tools is in your PATH and you've run `gclient sync`.
+
+### "use_sysroot" errors
+The sysroot is automatically downloaded by gclient. If it fails, try:
+```bash
+gclient sync --force --reset
+```
+
+### Build fails with missing headers
+Ensure all build dependencies are installed. The Chromium build has extensive requirements.
+
+### Slow build
+ARM cross-compilation is CPU-intensive. Use `autoninja` (which auto-detects parallelism) or set `-jN` manually based on your CPU cores.
+
+## Architecture Notes
+
+- `target_cpu = "arm"` builds for 32-bit ARM hard-float (armhf)
+- `target_cpu = "arm64"` builds for 64-bit ARM (aarch64)
+- The build system uses Debian Bullseye sysroots for cross-compilation
+- Vulkan/SwiftShader support may be limited on 32-bit ARM builds

--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -32,7 +32,7 @@ args = parser.parse_args()
 # Init variables.
 binaries_location = None        # .../out/Release
 platform_name = None            # win/linux/osx
-arch = None                     # ia32/x64/arm
+arch = None                     # ia32/x64/arm/armhf/armel
 step = None                     # nw/chromedriver/symbol
 skip = None
 nw_ver = None                   # x.xx
@@ -154,6 +154,15 @@ def generate_target_nw(platform_name, arch, version):
                            'lib/libnw.so',
                            'lib/libnode.so',
                            'lib/libffmpeg.so',
+                           ]
+        if arch in ('arm', 'armhf', 'armel'):
+            # ARM builds may not include Vulkan/SwiftShader
+            target['input'] += [
+                           'lib/libEGL.so',
+                           'lib/libGLESv2.so',
+                           ]
+        else:
+            target['input'] += [
                            'lib/libEGL.so',
                            'lib/libGLESv2.so',
                            'lib/libvulkan.so.1',
@@ -205,6 +214,8 @@ def generate_target_nw(platform_name, arch, version):
             target['input'].append('minidump_stackwalk')
             if arch == 'arm64':
                 target['input'].append('v8_context_snapshot.arm64.bin')
+            elif arch in ('arm', 'armhf', 'armel'):
+                target['input'].append('v8_context_snapshot.arm.bin')
             else:
                 target['input'].append('v8_context_snapshot.x86_64.bin')
     else:


### PR DESCRIPTION
## Summary

This PR adds ARM (armhf/armel) prebuilt binary support for NW.js, extending the existing ARM64 support to include 32-bit ARM devices like Raspberry Pi.

## Changes

### BUILD.gn
- Added armhf architecture mapping for target_cpu == arm in both the Linux dump and dist targets
- This ensures proper package naming for 32-bit ARM builds

### tools/package_binaries.py
- Updated architecture comment to include arm/armhf/armel
- Added ARM-specific handling for Linux binary packaging
- ARM builds may not include Vulkan/SwiftShader libraries
- Added v8_context_snapshot.arm.bin handling for ARM targets

### .github/workflows/build-arm.yml
- New GitHub Actions workflow for automated ARM cross-compilation
- Supports both ARM (armhf) and ARM64 (aarch64) builds
- Configurable for SDK and normal builds

### docs/Building-ARM.md
- Comprehensive documentation for building NW.js on ARM
- Includes prerequisites, build instructions, and troubleshooting

### README.md
- Updated Linux download section to include armhf binary link

Fixes #1151