### PR TITLE
harden: remove unsafe eval() in patcher.py...

### DIFF
--- a/tools/patcher.py
+++ b/tools/patcher.py
@@ -2,7 +2,7 @@
 # reserved. Use of this source code is governed by a BSD-style license that
 # can be found in the LICENSE file.
 
-import pickle
+import ast
 from optparse import OptionParser
 import os
 import sys
@@ -56,11 +56,17 @@ def apply_patch_config():
   if not os.path.isfile(config_file):
     raise Exception('Patch config file %s does not exist.' % config_file)
 
-  # Parse the configuration file.
-  scope = {}
+  # Parse the configuration file using safe AST literal evaluation.
   with open(config_file) as f:
-    exec(compile(f.read(), config_file, 'exec'), scope)
-  patches = scope["patches"]
+    tree = ast.parse(f.read(), config_file)
+  patches = None
+  for stmt in tree.body:
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and \
+       isinstance(stmt.targets[0], ast.Name) and stmt.targets[0].id == 'patches':
+      patches = ast.literal_eval(stmt.value)
+      break
+  if patches is None:
+    raise Exception('patches not defined in config file %s.' % config_file)
 
   results = {'apply': 0, 'skip': 0, 'fail': 0}
 


### PR DESCRIPTION
## Summary
Harden input handling in `tools/patcher.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | python.lang.security.audit.exec-detected.exec-detected |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `python.lang.security.audit.exec-detected.exec-detected` |
| **File** | `tools/patcher.py:62` |
| **Assessment** | Defensive hardening |

**Description**: Detected the use of exec(). exec() can be dangerous if used to evaluate dynamic content. If this content can be input from outside the program, this may be a code injection vulnerability. Ensure evaluated content is not definable by external sources.

## Threat Model Context

This is a Python library - vulnerabilities affect applications that import this code.

## Changes
- `tools/patcher.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
