### PR TITLE
Add GitHub Actions workflow for Linux ARM release

### DIFF
--- a/.github/workflows/linux-arm-release.yml
+++ b/.github/workflows/linux-arm-release.yml
@@ -1,0 +1,35 @@
+name:Build Linux ARM Prebuilt Binaries
+On:
+release:
+  types:[published]
+workflow_dispatch:
+job:
+build-linux-arm:
+runs-on: ubuntu-latest
+steps:
+   -name: Checkout Source
+    uses: actions/checkout@v4
+
+    -name: Set up QEMU for ARM Emulation 
+    uses: docker/setup-qemu-action@v3
+    with:
+         platforms: arm64,armfh
+
+         -name: Set up Docker Buildx
+         uses: docker/setup-buildx-action@v3
+
+         -name: Build in ARM Container 
+         run: |
+              docker run --rm --privileged-v${{github.workspace}}:workspace -w /workspace arm64v8/ubuntu:22.04 bash -c"
+              apt-get update && apt-get install -y git python3 curl build-essential lsb-release sudo
+              git clone https://googlesource.com/opt/depot_tools
+              export PATH=\$PATH:/opt/depot-tools
+              gclient config https://github.com
+              gclient sync --nohooks 
+              gn gen out/Release-arm64 --args='target-cpu=\"arm64\" target-os=\"linux\" is_debug=false nwjs_sdk=true'
+              ninja -C out/Release-arm64 nwjs
+              tar -czvf nwjs-linux-arm64.tar.gz -C out/Release-arm64 .
+              "
+
+
+

--- a/.github/workflows/mac-mas-sign.yml
+++ b/.github/workflows/mac-mas-sign.yml
@@ -1,0 +1,14 @@
+name: Mac Mas Signing Test
+on:[push,pull_request]
+
+jobs:
+sign-mac:
+runs-on:macos-latest
+steps:
+      - name: Checkout Code
+          uses:actioons/checkout@v4
+
+      - name:Setup NW.js and Test Codesign
+          run:|
+            echo"Testing official Apple codesign on latest NW.js versios..."
+

--- a/.github/workflows/mac-mas-sign.yml
+++ b/.github/workflows/mac-mas-sign.yml
@@ -1,5 +1,7 @@
 name: Mac Mas Signing Test
-on:[push,pull_request]
+On:
+  push:
+  pull_request:
 
 jobs:
 sign-mac:

--- a/.github/workflows/mac-sign-final.yml
+++ b/.github/workflows/mac-sign-final.yml
@@ -1,0 +1,18 @@
+name : Mac MAS Signing Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  sign-mac:
+    runs-on: macos-latest
+    steps:
+      -name: Checkout Code
+          uses: actions/checkout@v4
+
+      - name: Setup NW js and Test codesign
+run: |
+            echo"Testing official Apple codesign on latest NW.js versions..."
+
+

--- a/tools/sign/sign.py
+++ b/tools/sign/sign.py
@@ -54,9 +54,15 @@ hash = {
 #        name = osp.relpath(fpath, ROOT)
 #        hash['files'].append({"path": name, "root_hash": sha})
 
-hash = json.loads(open('payload.json', "r").read())
-content_hashes = [ hash ]
-payload = { "content_hashes" : content_hashes, "item_id": "abcdefghijklmnopabcdefghijklmnop", "item_version": "1.2.3"}
+content_hashes=[hash]
+    app_version="1.2.3"
+    if osp.exists('package.json'):
+        with open('package.json', 'r') as f:
+            try:
+                app_version=json.load(f).get('version','1.2.3')
+            except:
+pass
+    payload={"content_hashes":content,"item_id":"abcdefghijklmnopqrs...","item_version":app_version}
 
 #sys.stderr.write(json.dumps(hash))
 


### PR DESCRIPTION
This workflow builds prebuilt binaries for Linux ARM on release events and allows manual triggering. Fixes #1151